### PR TITLE
docs: update Vite watcher pattern to support nested routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ export default defineConfig({
             {
                 name: "wayfinder",
                 run: ["php", "artisan", "wayfinder:generate"],
-                pattern: ["routes/*.php", "app/**/Http/**/*.php"],
+                pattern: ["routes/**/*.php", "app/**/Http/**/*.php"],
             },
         ]),
     ],


### PR DESCRIPTION
This PR updates the documentation to support watching nested route files by changing the Vite watcher pattern from routes/*.php to routes/**/*.php.

This improves clarity for users organizing routes in subfolders.