### PR TITLE
fix: URL constructor: // is not a valid URL.

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -97,7 +97,8 @@ class Route
 
         $scheme = $this->scheme() ?? '//';
 
-        return str("/{$this->base->uri}")
+        return str("/")
+            ->when($this->base->uri !== '/', fn ($uri) => $uri->append($this->base->uri))
             ->when($this->domain() !== null, fn ($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
             ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
             ->toString();

--- a/src/Route.php
+++ b/src/Route.php
@@ -97,8 +97,8 @@ class Route
 
         $scheme = $this->scheme() ?? '//';
 
-        return str("/")
-            ->when($this->base->uri !== '/', fn ($uri) => $uri->append($this->base->uri))
+        return str($this->base->uri)
+            ->start('/')
             ->when($this->domain() !== null, fn ($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
             ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
             ->toString();

--- a/tests/EmptyRoute.test.ts
+++ b/tests/EmptyRoute.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "vitest";
+import { home } from "../workbench/resources/js/routes/home";
+
+it("doesn't add a / to an empty route", () => {
+    expect(home.url()).toBe("/");
+    expect(home()).toEqual({
+        url: "/",
+        method: "get",
+    });
+});

--- a/tests/NamedRoutes.test.ts
+++ b/tests/NamedRoutes.test.ts
@@ -1,10 +1,16 @@
 import { expect, it } from "vitest";
+import { home } from "../workbench/resources/js/routes/home";
 import { edit } from "../workbench/resources/js/routes/posts";
 
-it("exports default and methods for invokable controllers", () => {
+it("exports named routes", () => {
     expect(edit.url(1)).toBe("/posts/1/edit");
     expect(edit(1)).toEqual({
         url: "/posts/1/edit",
+        method: "get",
+    });
+    expect(home.url()).toBe("/");
+    expect(home()).toEqual({
+        url: "/",
         method: "get",
     });
 });

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -14,6 +14,10 @@ use App\Http\Controllers\UrlDefaultsController;
 use App\Http\Middleware\UrlDefaultsMiddleware;
 use Illuminate\Support\Facades\Route;
 
+Route::get('/', function() {
+    return 'Home';
+})->name('home');
+
 Route::get('/closure', fn () => 'ok');
 Route::get('/invokable-controller', InvokableController::class);
 Route::get('/invokable-plus-controller', InvokablePlusController::class);

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -31,6 +31,10 @@ Route::get('/dashboard', function () {
     return 'Dashboard';
 })->name('dashboard');
 
+Route::get('/', function () {
+    return 'Home';
+})->name('home');
+
 Route::post('/optional/{parameter?}', [OptionalController::class, 'optional']);
 Route::post('/many-optional/{one?}/{two?}/{three?}', [OptionalController::class, 'manyOptional']);
 


### PR DESCRIPTION
As described in Issue #18, a `/` route ends up creating a `//` url, which is invalid. Checking for this scenario and then appending the `$this->base->uri` fixed it locally for me.

```
return str("/")
            ->when($this->base->uri !== '/', fn ($uri) => $uri->append($this->base->uri))
            ->when($this->domain() !== null, fn ($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
            ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
            ->toString();
```

I'm open for a more elegant solution, but for now this fixes the issue 

![image](https://github.com/user-attachments/assets/2bafb0f5-0f18-4baa-8869-c3ba17806dea)

and all the `npm run test` were passing

```
➜  wayfinder git:(main) npm run test

> test
> vitest run


 RUN  v2.1.9 /Users/******/Documents/GitHub/wayfinder

 ✓ tests/AnonymousMiddleware.test.ts (1)
 ✓ tests/DisallowedMethodNames.test.ts (1)
 ✓ tests/DomainController.test.ts (2)
 ✓ tests/InvokableController.test.ts (1)
 ✓ tests/InvokablePlusController.test.ts (1)
 ✓ tests/KeyController.test.ts (3)
 ✓ tests/NamedRoutes.test.ts (1)
 ✓ tests/OptionalController.test.ts (5)
 ✓ tests/ParamaterName.test.ts (8)
 ✓ tests/PathNameNormalization.test.ts (1)
 ✓ tests/PostController.test.ts (42)
 ✓ tests/QueryParams.test.ts (11)
 ✓ tests/TwoRoutesSameAction.test.ts (1)
 ✓ tests/UrlDefaultsController.test.ts (4)

 Test Files  14 passed (14)
      Tests  82 passed (82)
   Start at  11:54:29
   Duration  1.92s (transform 334ms, setup 0ms, collect 943ms, tests 43ms, environment 3.96s, prepare 880ms)
```