### PR TITLE
Configurable rename_methods using config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ update({ post: 1, author: 2 });
 update({ post: { id: 1 }, author: { id: 2 } });
 ```
 
-**Note:** If you have a `delete` method on your controller, Wayfinder will rename it to `deleteMethod` when generating its functions. This is because `delete` is not allowed as a variable declaration.
+**Note:** If you have a `delete` method on your controller, Wayfinder will rename it to `deleteMethod` when generating its functions. This is because `delete` is not allowed as a variable declaration. You can publish the config file if you want to rename more methods, using this command.
+
+```php
+php artisan vendor:publish --provider="Laravel\Wayfinder\WayfinderServiceProvider" --tag="wayfinder-config"
+```
 
 If you've specified a key for the parameter binding, Wayfinder will detect this and allow you to pass the value in as a property on an object:
 

--- a/config/wayfinder.php
+++ b/config/wayfinder.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+
+    /*
+     * Rename generated javascript methods to prevent using reserved words.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words
+     */
+    'rename_methods' => [
+        'delete' => 'deleteMethod',
+    ],
+
+];

--- a/src/Route.php
+++ b/src/Route.php
@@ -165,10 +165,9 @@ class Route
 
     private function finalJsMethod(string $method): string
     {
-        $method = match ($method) {
-            'delete' => 'deleteMethod',
-            default => $method,
-        };
+        $renameMethods = config('wayfinder.rename_methods', []);
+
+        $method = $renameMethods[$method] ?? $method;
 
         if (is_numeric($method)) {
             return 'method'.$method;

--- a/src/WayfinderServiceProvider.php
+++ b/src/WayfinderServiceProvider.php
@@ -6,8 +6,19 @@ use Illuminate\Support\ServiceProvider;
 
 class WayfinderServiceProvider extends ServiceProvider
 {
+    public function register()
+    {
+        if (! app()->configurationIsCached()) {
+            $this->mergeConfigFrom(__DIR__.'/../config/wayfinder.php', 'wayfinder');
+        }
+    }
+
     public function boot(): void
     {
+        $this->publishes([
+            __DIR__.'/../config/wayfinder.php' => config_path('wayfinder.php'),
+        ], 'wayfinder-config');
+
         if ($this->app->runningInConsole()) {
             $this->commands([
                 GenerateCommand::class,


### PR DESCRIPTION
Currently only `delete` is renamed to `deleteMethod`. But, there are many other javascript [reserved words](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words). For example, routes like `users.import`, `report.export` can also cause problems.

I have added `wayfinder.php` config file, which allows to add `rename_methods`.

It only includes `delete`, but may be common methods like `import`, `export` should also be added?