### PR TITLE
fix: build.ts on Windows

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,9 +1,12 @@
 import { execSync } from "node:child_process";
+import path from "node:path";
 
 export default function setup() {
     try {
+        const testbenchDir = path.join(__dirname, "vendor", "bin", "testbench");
+
         execSync(
-            "vendor/bin/testbench wayfinder:generate --path=workbench/resources/js --with-form",
+            `${testbenchDir} wayfinder:generate --path=workbench/resources/js --with-form`,
         );
     } catch (error) {
         console.error(


### PR DESCRIPTION
Use `path.join()` for `build.ts` to work on Windows.

Otherwise it fail with `'vendor' is not recognized as an internal or external command`.