### PR TITLE
Remove trim deadspace directive for function arguments

### DIFF
--- a/resources/function-arguments.blade.ts
+++ b/resources/function-arguments.blade.ts
@@ -1,4 +1,3 @@
-@trimDeadspace
 @if ($parameters->isNotEmpty())
 args{!! when($parameters->every->optional, '?') !!}: {
     @foreach ($parameters as $parameter)
@@ -25,4 +24,3 @@ args{!! when($parameters->every->optional, '?') !!}: {
 ,
 @endif
 options?: { query?: QueryParams, mergeQuery?: QueryParams }
-@endtrimDeadspace

--- a/resources/method.blade.ts
+++ b/resources/method.blade.ts
@@ -1,4 +1,3 @@
-@use('Illuminate\Support\HtmlString')
 @include('wayfinder::docblock')
 {!! when(($export ?? true) && !$isInvokable, 'export ') !!}const {!! $method !!} = (@include('wayfinder::function-arguments')): {
     url: string,

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -9,7 +9,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Factory;
 use ReflectionProperty;
 
@@ -35,7 +34,6 @@ class GenerateCommand extends Command
         private Router $router,
         private Factory $view,
         private UrlGenerator $url,
-        private BladeCompiler $bladeCompiler,
     ) {
         parent::__construct();
     }
@@ -44,12 +42,6 @@ class GenerateCommand extends Command
     {
         $this->view->addNamespace('wayfinder', __DIR__.'/../resources');
         $this->view->addExtension('blade.ts', 'blade');
-        $this->bladeCompiler->directive('trimDeadspace', function () {
-            return '<?php ob_start(); ?>';
-        });
-        $this->bladeCompiler->directive('endtrimDeadspace', function () {
-            return '<?php echo \Laravel\Wayfinder\TypeScript::trimDeadspace(ob_get_clean()); ?>';
-        });
 
         $this->forcedScheme = (new ReflectionProperty($this->url, 'forceScheme'))->getValue($this->url);
         $this->forcedRoot = (new ReflectionProperty($this->url, 'forcedRoot'))->getValue($this->url);

--- a/src/TypeScript.php
+++ b/src/TypeScript.php
@@ -2,20 +2,10 @@
 
 namespace Laravel\Wayfinder;
 
+use Illuminate\Support\Stringable;
+
 class TypeScript
 {
-    public static function trimDeadspace(string $view): string
-    {
-        return str($view)
-            ->replaceMatches('/\s+/', ' ')
-            ->replace(' ,', ',')
-            ->replace('[ ', '[')
-            ->replace(' ]', ']')
-            ->replace(', }', ' }')
-            ->trim()
-            ->toString();
-    }
-
     public static function cleanUp(string $view): string
     {
         $replacements = [
@@ -30,6 +20,16 @@ class TypeScript
         ];
 
         return str($view)
+            ->pipe(function (Stringable $str) {
+                // Clean up function arguments
+                $matches = $str->matchAll('/ = \(([^)]+\))/');
+
+                foreach ($matches as $match) {
+                    $str = $str->replaceFirst($match, preg_replace('/\s+/', ' ', $match));
+                }
+
+                return $str;
+            })
             ->replaceMatches('/\n{3,}/', "\n\n")
             ->replace(array_keys($replacements), array_values($replacements))
             ->toString();


### PR DESCRIPTION
This PR removes the `@trimDeadspace` directive and moves the logic to a simple regex in the cleanup phase.

Fixes #9 