### PR TITLE
Expanded list of JavaScript reserved words

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ update({ post: 1, author: 2 });
 update({ post: { id: 1 }, author: { id: 2 } });
 ```
 
-**Note:** If you have a `delete` method on your controller, Wayfinder will rename it to `deleteMethod` when generating its functions. This is because `delete` is not allowed as a variable declaration.
+**Note:** If you have are using a JavaScript [reserved word](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#reserved_words) as a method on your controller, Wayfinder will rename it to `[method name]Method` when generating its functions. This is because these words are not allowed as variable declarations.
 
 If you've specified a key for the parameter binding, Wayfinder will detect this and allow you to pass the value in as a property on an object:
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -77,12 +77,12 @@ class Route
 
         $signatureParams = collect($this->base->signatureParameters(UrlRoutable::class));
 
-        return collect($this->base->parameterNames())->map(fn($name) => new Parameter(
+        return collect($this->base->parameterNames())->map(fn ($name) => new Parameter(
             $name,
             $optionalParameters->has($name) || $this->paramDefaults->has($name),
             $this->base->bindingFieldFor($name),
             $this->paramDefaults->get($name),
-            $signatureParams->first(fn($p) => $p->getName() === $name),
+            $signatureParams->first(fn ($p) => $p->getName() === $name),
         ));
     }
 
@@ -93,13 +93,13 @@ class Route
 
     public function uri(): string
     {
-        $defaultParams = $this->paramDefaults->mapWithKeys(fn($value, $key) => ["{{$key}}" => "{{$key}?}"]);
+        $defaultParams = $this->paramDefaults->mapWithKeys(fn ($value, $key) => ["{{$key}}" => "{{$key}?}"]);
 
         $scheme = $this->scheme() ?? '//';
 
         return str($this->base->uri)
             ->start('/')
-            ->when($this->domain() !== null, fn($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
+            ->when($this->domain() !== null, fn ($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
             ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
             ->toString();
     }
@@ -203,10 +203,10 @@ class Route
             'with',
         ];
 
-        $method = in_array($method, $reserved) ? $method . 'Method' : $method;
+        $method = in_array($method, $reserved) ? $method.'Method' : $method;
 
         if (is_numeric($method)) {
-            return 'method' . $method;
+            return 'method'.$method;
         }
 
         return $method;

--- a/src/Route.php
+++ b/src/Route.php
@@ -77,12 +77,12 @@ class Route
 
         $signatureParams = collect($this->base->signatureParameters(UrlRoutable::class));
 
-        return collect($this->base->parameterNames())->map(fn ($name) => new Parameter(
+        return collect($this->base->parameterNames())->map(fn($name) => new Parameter(
             $name,
             $optionalParameters->has($name) || $this->paramDefaults->has($name),
             $this->base->bindingFieldFor($name),
             $this->paramDefaults->get($name),
-            $signatureParams->first(fn ($p) => $p->getName() === $name),
+            $signatureParams->first(fn($p) => $p->getName() === $name),
         ));
     }
 
@@ -93,13 +93,13 @@ class Route
 
     public function uri(): string
     {
-        $defaultParams = $this->paramDefaults->mapWithKeys(fn ($value, $key) => ["{{$key}}" => "{{$key}?}"]);
+        $defaultParams = $this->paramDefaults->mapWithKeys(fn($value, $key) => ["{{$key}}" => "{{$key}?}"]);
 
         $scheme = $this->scheme() ?? '//';
 
         return str($this->base->uri)
             ->start('/')
-            ->when($this->domain() !== null, fn ($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
+            ->when($this->domain() !== null, fn($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
             ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
             ->toString();
     }
@@ -165,13 +165,48 @@ class Route
 
     private function finalJsMethod(string $method): string
     {
-        $method = match ($method) {
-            'delete' => 'deleteMethod',
-            default => $method,
-        };
+        $reserved = [
+            'break',
+            'case',
+            'catch',
+            'class',
+            'const',
+            'continue',
+            'debugger',
+            'default',
+            'delete',
+            'do',
+            'else',
+            'export',
+            'extends',
+            'false',
+            'finally',
+            'for',
+            'function',
+            'if',
+            'import',
+            'in',
+            'instanceof',
+            'new',
+            'null',
+            'return',
+            'super',
+            'switch',
+            'this',
+            'throw',
+            'true',
+            'try',
+            'typeof',
+            'var',
+            'void',
+            'while',
+            'with',
+        ];
+
+        $method = in_array($method, $reserved) ? $method . 'Method' : $method;
 
         if (is_numeric($method)) {
-            return 'method'.$method;
+            return 'method' . $method;
         }
 
         return $method;


### PR DESCRIPTION
The PR builds on the information provided in #21, expanding the list of JavaScript reserved words to handle beyond `delete`.