### PR TITLE
Show support for both Vue and React

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ import { show } from "@actions/App/Http/Controllers/PostController";
 ```
 
 > [!IMPORTANT]
-> Support for Wayfinder-shaped objects in `useForm` and `Link` was added to Inertia in [v2.0.6](https://github.com/inertiajs/inertia/releases/tag/v2.0.6)
+> Support for the use of Wayfinder-shaped objects in Inertia's `useForm` and `Link` components was added to Inertia in [v2.0.6](https://github.com/inertiajs/inertia/releases/tag/v2.0.6).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,20 @@ const form = useForm({
 form.submit(store()); // Will POST to `/posts`...
 ```
 
-You may also use Wayfinder in conjunction with Inertia's `Link` component:
+Wayfinder works in both React and Vue environments. For example, you can accomplish the same thing in Vue:
+
+```tsx
+import { useForm } from "@inertiajs/vue";
+import { store } from "@actions/App/Http/Controllers/PostController";
+
+const form = useForm({
+    name: "My Big Post",
+});
+
+form.submit(store()); // Will POST to `/posts`...
+```
+
+You may also use Wayfinder in conjunction with Inertia's `Link` component. In React:
 
 ```tsx
 import { Link } from "@inertiajs/react";
@@ -276,6 +289,22 @@ import { show } from "@actions/App/Http/Controllers/PostController";
 
 const Nav = () => <Link href={show(1)}>Show me the first post</Link>;
 ```
+
+And in Vue:
+
+```vue
+<script setup lang="ts">
+import { Link } from "@inertiajs/vue";
+import { show } from "@actions/App/Http/Controllers/PostController";
+</script>
+
+<template>
+    <Link :href="show(1)">Show me the first post</Link>
+</template>
+```
+
+> [!IMPORTANT]
+> Support for Wayfinder-shaped objects in `useForm` and `Link` was added to Inertia in [v2.0.6](https://github.com/inertiajs/inertia/releases/tag/v2.0.6)
 
 ## Contributing
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR updates the readme to show that both React and Vue are supported through Inertia ("closes" #22).