### PR TITLE
Check possible undefined

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -60,7 +60,9 @@ export const queryParams = (options?: {
             });
 
             for (const subKey in query[key]) {
-                params.set(`${key}[${subKey}]`, getValue(query[key][subKey]));
+                if (query[key][subKey] !== undefined) {
+                    params.set(`${key}[${subKey}]`, getValue(query[key][subKey]));
+                }
             }
         } else {
             params.set(key, getValue(query[key]));

--- a/tests/QueryParams.test.ts
+++ b/tests/QueryParams.test.ts
@@ -168,3 +168,29 @@ it("can merge with the form method", () => {
         method: "get",
     });
 });
+
+it("handles nested objects with undefined keys", () => {
+    window.location.search = "?parent=og";
+
+    const query = (): {
+        good: string;
+    } => {
+        const obj = {
+            good: 'value',
+            bad: undefined,
+        }
+
+        return obj
+    }
+
+    expect(
+        index.form.head({
+            mergeQuery: {
+                parent: query(),
+            },
+        }),
+    ).toEqual({
+        action: "/posts?parent=og&_method=HEAD&parent%5Bgood%5D=value",
+        method: "get",
+    });
+});


### PR DESCRIPTION
This PR adds a verification for potential undefined values when `noUncheckedIndexedAccess` is set to `true` in the TS configuration.

![CleanShot 2025-04-05 at 11  34 32@2x](https://github.com/user-attachments/assets/cca1f3d8-c2b5-4b32-8c03-b537eb825d7e)