### PR TITLE
Add route prefix to reserved js keyword route names

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -202,18 +202,8 @@ class GenerateCommand extends Command
         $imports = $routes->map(fn (Route $route) => $route->namedMethod())->implode(', ');
 
         $basename = basename($path, '.ts');
-        $base = Str::of($basename)->when(
-            str_contains($basename, '-'),
-            fn ($s) => $s->camel()
-        )->toString();
 
-        if (in_array($base, TypeScript::RESERVED_KEYWORDS)) {
-            $base = $base.'Route';
-        }
-
-        if (is_numeric($base)) {
-            $base = 'route'.$base;
-        }
+        $base = TypeScript::safeMethod($basename, 'Route');
 
         if ($base !== $imports) {
             $this->appendContent($path, "const {$base} = { {$imports} }\n");

--- a/src/Route.php
+++ b/src/Route.php
@@ -56,12 +56,7 @@ class Route
 
     public function namedMethod(): string
     {
-        $base = Str::afterLast($this->name(), '.');
-
-        return $this->finalJsMethod(
-            str_contains($base, '-') ?
-                Str::camel($base) : $base
-        );
+        return $this->finalJsMethod(Str::afterLast($this->name(), '.'));
     }
 
     public function controller(): string
@@ -165,13 +160,7 @@ class Route
 
     private function finalJsMethod(string $method): string
     {
-        $method = in_array($method, TypeScript::RESERVED_KEYWORDS) ? $method.'Method' : $method;
-
-        if (is_numeric($method)) {
-            return 'method'.$method;
-        }
-
-        return $method;
+        return TypeScript::safeMethod($method, 'Method');
     }
 
     private function relativePath(string $path)

--- a/src/TypeScript.php
+++ b/src/TypeScript.php
@@ -44,6 +44,27 @@ class TypeScript
         'with',
     ];
 
+    public static function safeMethod(string $method, string $suffix): string
+    {
+        $method = str($method);
+
+        if ($method->contains('-')) {
+            $method = $method->camel();
+        }
+
+        $suffix = strtolower($suffix);
+
+        if (in_array($method, self::RESERVED_KEYWORDS)) {
+            return $method->append(ucfirst($suffix));
+        }
+
+        if (is_numeric((string) $method)) {
+            return $method->prepend($suffix);
+        }
+
+        return $method;
+    }
+
     public static function cleanUp(string $view): string
     {
         $replacements = [

--- a/tests/DisallowedMethodNames.test.ts
+++ b/tests/DisallowedMethodNames.test.ts
@@ -3,6 +3,7 @@ import DisallowedMethodNameController, {
     deleteMethod,
     method404,
 } from "../workbench/resources/js/actions/App/Http/Controllers/DisallowedMethodNameController";
+import route404 from "../workbench/resources/js/routes/disallowed/404";
 
 test("will append `method` to invalid methods", () => {
     expect(method404.url()).toBe("/disallowed/404");
@@ -11,4 +12,8 @@ test("will append `method` to invalid methods", () => {
         "/disallowed/delete",
     );
     expect(DisallowedMethodNameController[404].url()).toBe("/disallowed/404");
+});
+
+test("will append `method` to invalid methods", () => {
+    expect(route404.method404.url()).toBe("/disallowed/404");
 });

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -66,7 +66,7 @@ Route::get('/two-routes-one-action-1', [TwoRoutesSameActionController::class, 's
 Route::get('/two-routes-one-action-2', [TwoRoutesSameActionController::class, 'same']);
 
 Route::get('/disallowed/delete', [DisallowedMethodNameController::class, 'delete']);
-Route::get('/disallowed/404', [DisallowedMethodNameController::class, '404']);
+Route::get('/disallowed/404', [DisallowedMethodNameController::class, '404'])->name('disallowed.404');
 
 Route::get('/anonymous-middleware', [AnonymousMiddlewareController::class, 'show']);
 


### PR DESCRIPTION
This pr closes #31 

We were checking names is valid typescript for methods but not for routes. This pr adds that
