### PR TITLE
Update README.md to improve integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,6 @@ export default defineConfig({
 });
 ```
 
-For convenience, you may also wish to register aliases for importing the generated files into your application:
-
-```ts
-import path from 'path';
-
-export default defineConfig({
-    // ...
-    resolve: {
-        alias: {
-            "@": path.resolve(__dirname, "./resources/js"),
-        },
-    },
-});
-```
-
 ## Generating TypeScript Definitions
 
 The `wayfinder:generate` command can be used to generate TypeScript definitions for your routes and controller methods:
@@ -87,6 +72,8 @@ import { show } from "@/actions/App/Http/Controllers/PostController";
 
 show(1); // { url: "/posts/1", method: "get" }
 ```
+> [!NOTE]
+> The @ alias can be used for convenience. It's available by default when using [Laravel Vite Plugin](https://github.com/laravel/vite-plugin). To let Typescript also understand this alias, make sure it's configured in your tsconfig.json in the paths section under compilerOptions: `"paths": {"@/*": ["./resources/js/*"]}`.
 
 If you just need the URL, or would like to choose a method from the HTTP methods defined on the server, you can invoke additional methods on the Wayfinder generated function:
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ import { show } from "@/actions/App/Http/Controllers/PostController";
 
 show(1); // { url: "/posts/1", method: "get" }
 ```
-> [!NOTE]
-> The @ alias can be used for convenience. It's available by default when using [Laravel Vite Plugin](https://github.com/laravel/vite-plugin). To let Typescript also understand this alias, make sure it's configured in your tsconfig.json in the paths section under compilerOptions: `"paths": {"@/*": ["./resources/js/*"]}`.
 
 If you just need the URL, or would like to choose a method from the HTTP methods defined on the server, you can invoke additional methods on the Wayfinder generated function:
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,13 @@ export default defineConfig({
 For convenience, you may also wish to register aliases for importing the generated files into your application:
 
 ```ts
+import path from 'path';
+
 export default defineConfig({
     // ...
     resolve: {
         alias: {
-            "@actions/": "./resources/js/actions",
-            "@routes/": "./resources/js/routes",
+            "@": path.resolve(__dirname, "./resources/js"),
         },
     },
 });
@@ -82,7 +83,7 @@ You can safely `.gitignore` the `wayfinder`, `actions`, and `routes` directories
 Wayfinder functions return an object that contains the resolved URL and default HTTP method:
 
 ```ts
-import { show } from "@actions/App/Http/Controllers/PostController";
+import { show } from "@/actions/App/Http/Controllers/PostController";
 
 show(1); // { url: "/posts/1", method: "get" }
 ```
@@ -90,7 +91,7 @@ show(1); // { url: "/posts/1", method: "get" }
 If you just need the URL, or would like to choose a method from the HTTP methods defined on the server, you can invoke additional methods on the Wayfinder generated function:
 
 ```ts
-import { show } from "@actions/App/Http/Controllers/PostController";
+import { show } from "@/actions/App/Http/Controllers/PostController";
 
 show.url(1); // "/posts/1"
 show.head(1); // { url: "/posts/1", method: "head" }
@@ -99,7 +100,7 @@ show.head(1); // { url: "/posts/1", method: "head" }
 Wayfinder functions accept a variety of shapes for their arguments:
 
 ```ts
-import { show, update } from "@actions/App/Http/Controllers/PostController";
+import { show, update } from "@/actions/App/Http/Controllers/PostController";
 
 // Single parameter action...
 show(1);
@@ -117,7 +118,7 @@ update({ post: { id: 1 }, author: { id: 2 } });
 If you've specified a key for the parameter binding, Wayfinder will detect this and allow you to pass the value in as a property on an object:
 
 ```ts
-import { show } from "@actions/App/Http/Controllers/PostController";
+import { show } from "@/actions/App/Http/Controllers/PostController";
 
 // Route is /posts/{post:slug}...
 show("my-new-post");
@@ -129,7 +130,7 @@ show({ slug: "my-new-post" });
 If your controller is an invokable controller, you may simple invoke the imported Wayfinder function directly:
 
 ```ts
-import StorePostController from "@actions/App/Http/Controllers/StorePostController";
+import StorePostController from "@/actions/App/Http/Controllers/StorePostController";
 
 StorePostController();
 ```
@@ -139,7 +140,7 @@ StorePostController();
 You may also import the Wayfinder generated controller definition and invoke its individual methods on the imported object:
 
 ```ts
-import PostController from "@actions/App/Http/Controllers/PostController";
+import PostController from "@/actions/App/Http/Controllers/PostController";
 
 PostController.show(1);
 ```
@@ -152,7 +153,7 @@ PostController.show(1);
 Wayfinder can also generate methods for your application's named routes as well:
 
 ```ts
-import { show } from "@routes/post";
+import { show } from "@/routes/post";
 
 // Named route is `post.show`...
 show(1); // { url: "/posts/1", method: "get" }
@@ -169,7 +170,7 @@ php artisan wayfinder:generate --with-form
 Then, you can use the `.form` variant to generate `<form>` object attributes automatically:
 
 ```tsx
-import { store, update } from "@actions/App/Http/Controllers/PostController";
+import { store, update } from "@/actions/App/Http/Controllers/PostController";
 
 const Page = () => (
     <form {...store.form()}>
@@ -189,7 +190,7 @@ const Page = () => (
 If your form action supports multiple methods and would like to specify a method, you can invoke additional methods on the `form`:
 
 ```tsx
-import { store, update } from "@actions/App/Http/Controllers/PostController";
+import { store, update } from "@/actions/App/Http/Controllers/PostController";
 
 const Page = () => (
     <form {...update.form.put(1)}>
@@ -204,7 +205,7 @@ const Page = () => (
 All Wayfinder methods accept an optional, final `options` argument to which you may pass a `query` object. This object can be used to append query parameters onto the resulting URL:
 
 ```ts
-import { show } from "@actions/App/Http/Controllers/PostController";
+import { show } from "@/actions/App/Http/Controllers/PostController";
 
 const options = {
     query: {
@@ -222,7 +223,7 @@ show.form.head(1, options); // { action: "/posts/1?page=1&sort_by=name&_method=H
 You can also merge with the URL's existing parameters by passing a `mergeQuery` object instead:
 
 ```ts
-import { show } from "@actions/App/Http/Controllers/PostController";
+import { show } from "@/actions/App/Http/Controllers/PostController";
 
 // window.location.search = "?page=1&sort_by=category&q=shirt"
 
@@ -239,7 +240,7 @@ show.url(1, options); // "/posts/1?page=2&sort_by=name&q=shirt"
 If you would like to remove a parameter from the resulting URL, define the value as `null` or `undefined`:
 
 ```ts
-import { show } from "@actions/App/Http/Controllers/PostController";
+import { show } from "@/actions/App/Http/Controllers/PostController";
 
 // window.location.search = "?page=1&sort_by=category&q=shirt"
 
@@ -261,7 +262,7 @@ When using [Inertia](https://inertiajs.com), you can pass the result of a Wayfin
 
 ```ts
 import { useForm } from "@inertiajs/react";
-import { store } from "@actions/App/Http/Controllers/PostController";
+import { store } from "@/actions/App/Http/Controllers/PostController";
 
 const form = useForm({
     name: "My Big Post",
@@ -276,7 +277,7 @@ You may also use Wayfinder in conjunction with Inertia's `Link` component:
 
 ```tsx
 import { Link } from "@inertiajs/react";
-import { show } from "@actions/App/Http/Controllers/PostController";
+import { show } from "@/actions/App/Http/Controllers/PostController";
 
 const Nav = () => <Link href={show(1)}>Show me the first post</Link>;
 ```


### PR DESCRIPTION
Strictly following the current readme doesn't result in Wayfinder working properly (with at least Vue). The following changes should:
- The suggested aliases require you to als update your tsconfig, else it's not aware of the aliases (this is not mentioned in the readme). Suggestion: just instruct to setup the general `@` alias.
- Defining a relative path is not recommend as per [vite.dev](https://vite.dev/config/shared-options?utm_source=chatgpt.com#resolve-alias): "When aliasing to file system paths, always use absolute paths. Relative alias values will be used as-is and will not be resolved into file system paths."
- Updated all `@routes` and `@actions` to `@/routes` and `@/actions`
