### PR TITLE
php 8.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4]
+        php: [8.2, 8.3, 8.4]
         laravel: [11, 12]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "illuminate/console": "^11.0|^12.0",
         "illuminate/filesystem": "^11.0|^12.0",
         "illuminate/routing": "^11.0|^12.0",


### PR DESCRIPTION
This PR modifies the PHP version requirement to support PHP 8.2+ to align with Laravel 11 and 12's own PHP version support.

By changing the requirement from a higher PHP version to ^8.2, we enable Wayfinder to be used in environments that are running PHP 8.2, which is still fully supported by Laravel 11 and 12. This provides wider compatibility and better adoption opportunities for the package without compromising functionality.
