### PR TITLE
Fix: Use forward slashes in docblock paths

### DIFF
--- a/resources/docblock.blade.ts
+++ b/resources/docblock.blade.ts
@@ -1,5 +1,5 @@
 /**{!! when(!str_contains($controller, '\\Closure'), PHP_EOL . " * @see {$controller}::" . ($isInvokable ? '__invoke' : $docblock_method ?? $method)) !!}
- * @see {!! str_replace(DIRECTORY_SEPARATOR, '/', $path) !!}:{!! $line !!}
+ * @see {!! $path !!}:{!! $line !!}
 @foreach ($parameters as $parameter)
 @if ($parameter->default !== null)
  * @param {!! $parameter->name !!} - Default: @js($parameter->default)

--- a/resources/docblock.blade.ts
+++ b/resources/docblock.blade.ts
@@ -1,5 +1,5 @@
 /**{!! when(!str_contains($controller, '\\Closure'), PHP_EOL . " * @see {$controller}::" . ($isInvokable ? '__invoke' : $docblock_method ?? $method)) !!}
- * @see {!! $path !!}:{!! $line !!}
+ * @see {!! str_replace(DIRECTORY_SEPARATOR, '/', $path) !!}:{!! $line !!}
 @foreach ($parameters as $parameter)
 @if ($parameter->default !== null)
  * @param {!! $parameter->name !!} - Default: @js($parameter->default)

--- a/src/Route.php
+++ b/src/Route.php
@@ -183,7 +183,7 @@ class Route
 
     private function relativePath(string $path)
     {
-        return ltrim(str_replace(base_path(), '', $path), DIRECTORY_SEPARATOR);
+        return str($path)->replace(base_path(), '')->ltrim(DIRECTORY_SEPARATOR)->replace(DIRECTORY_SEPARATOR, '/')->toString();
     }
 
     private function closure(): Closure


### PR DESCRIPTION
This PR ensures that file paths in generated `@see` docblock tags consistently use forward slashes (`/`) as the separator, regardless of the host operating system.

### Why?
When the generated Wayfinder file is committed to version control by developers on different operating systems, this leads to unnecessary diffs like the one shown below, cluttering the commit history:

```diff
 /**
  * @see \App\Domains\Contact\Actions\DeleteContact::DeleteContact
- * @see app/Domains/Contact/Actions/DeleteContact.php:13
+ * @see app\Domains\Contact\Actions\DeleteContact.php:13
  * @route /contacts/{record}
  */
```

Since Windows also supports forward slashes in paths, this won't cause any issue.

Grateful for your work, folks 🙏
