### PR TITLE
feat: Add multiple imports handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+    "env": {
+        "es2022": true,
+        "node": true
+    },
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": ["@typescript-eslint", "import"],
+    "rules": {
+        "import/no-duplicates": "error"
+    }
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@ jobs:
       matrix:
         php: [8.2, 8.3, 8.4]
         laravel: [11, 12]
+        exclude:
+          - php: 8.4
+            laravel: 11
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,6 @@ jobs:
       matrix:
         php: [8.2, 8.3, 8.4]
         laravel: [11, 12]
-        exclude:
-          - php: 8.4
-            laravel: 11
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
     "type": "module",
     "scripts": {
-        "test": "vitest run && npm run test-routes-cached",
-        "test-routes-cached": "WAYFINDER_CACHE_ROUTES=1 vitest run"
+        "test": "vitest run && npm run lint && npm run test-routes-cached && npm run lint",
+        "test-routes-cached": "WAYFINDER_CACHE_ROUTES=1 vitest run",
+        "lint": "eslint ./workbench/resources/js --ext .ts,.tsx",
+        "lint:fix": "eslint ./workbench/resources/js --ext .ts,.tsx --fix"
     },
     "devDependencies": {
         "@types/node": "^22.7.5",
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0",
+        "eslint-plugin-import": "^2.29.1",
         "happy-dom": "^15.11.7",
         "vitest": "^2.1.3"
     }

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -126,7 +126,7 @@ class GenerateCommand extends Command
 
             // Prepend the imports to the file
             if (isset($this->imports[$path])) {
-                $importLines = collect($this->imports[$path])->map(fn ($imports, $key) => "import { ".implode(', ', array_unique($imports))." } from '{$key}'")->implode(PHP_EOL);
+                $importLines = collect($this->imports[$path])->map(fn ($imports, $key) => 'import { '.implode(', ', array_unique($imports))." } from '{$key}'")->implode(PHP_EOL);
                 $this->files->prepend($path, $importLines.PHP_EOL);
             }
         }
@@ -229,14 +229,12 @@ class GenerateCommand extends Command
         }
 
         $importBase = str_repeat('/..', substr_count($namespace, '.') + 1);
+        $pathKey = ".{$importBase}/wayfinder";
 
-        if (!isset($this->imports[$path])) {
-            $this->imports[$path] = [];
-        }
-
-        $this->imports[$path][".{$importBase}/wayfinder"] = [
-            ...($this->imports[$path][".{$importBase}/wayfinder"] ?? []),
-            ...$imports
+        $this->imports[$path] ??= [];
+        $this->imports[$path][$pathKey] = [
+            ...($this->imports[$path][$pathKey] ?? []),
+            ...$imports,
         ];
     }
 

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -29,6 +29,14 @@ class GenerateCommand extends Command
 
     private $content = [];
 
+    /**
+     * Imports array where the key is the generated file path and the value is an array of imports.
+     * Each import is an array where the first element is the import path and the second element is an array of imported items.
+     *
+     * @var array<string, array<string, string[]>>
+     */
+    private $imports = [];
+
     public function __construct(
         private Filesystem $files,
         private Router $router,
@@ -115,6 +123,12 @@ class GenerateCommand extends Command
         foreach ($this->content as $path => $content) {
             $this->files->ensureDirectoryExists(dirname($path));
             $this->files->put($path, TypeScript::cleanUp(implode(PHP_EOL, $content)));
+
+            // Prepend the imports to the file
+            if (isset($this->imports[$path])) {
+                $importLines = collect($this->imports[$path])->map(fn ($imports, $key) => "import { ".implode(', ', array_unique($imports))." } from '{$key}'")->implode(PHP_EOL);
+                $this->files->prepend($path, $importLines.PHP_EOL);
+            }
         }
 
         $this->content = [];
@@ -216,7 +230,14 @@ class GenerateCommand extends Command
 
         $importBase = str_repeat('/..', substr_count($namespace, '.') + 1);
 
-        $this->appendContent($path, 'import { '.implode(', ', $imports)." } from '.{$importBase}/wayfinder'".PHP_EOL);
+        if (!isset($this->imports[$path])) {
+            $this->imports[$path] = [];
+        }
+
+        $this->imports[$path][".{$importBase}/wayfinder"] = [
+            ...($this->imports[$path][".{$importBase}/wayfinder"] ?? []),
+            ...$imports
+        ];
     }
 
     private function writeNamedMethodExport(Route $route, string $path): void

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -41,7 +41,7 @@ Route::get('/', function () {
     return 'Home';
 })->name('home');
 
-Route::post('/optional/{parameter?}', [OptionalController::class, 'optional']);
+Route::post('/optional/{parameter?}', [OptionalController::class, 'optional'])->name('optional');
 Route::post('/many-optional/{one?}/{two?}/{three?}', [OptionalController::class, 'manyOptional']);
 
 Route::post('/users/{user}', [ModelBindingController::class, 'show']);


### PR DESCRIPTION
This PR is a way to manage the imports that are added to a file.

## The issue
The current method of adding the imports checks if the import line has already been added to the file. But this won't work in the case described in #62, and the file is generated with two import lines with common import members, causing JS to throw an error

## Proposed solution
The new method will ensure the relevant imports are added to the top of the file and every import path is only imported once with its members.

Fixes #62