### PR TITLE
Add --ignore-routes option to allow route filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ php artisan wayfinder:generate --skip-actions
 php artisan wayfinder:generate --skip-routes
 ```
 
+If you want to exclude specific routes from being generated, you can use the `--ignore-routes` option and pass a comma-separated list of route names to ignore:
+
+```
+php artisan wayfinder:generate --ignore-routes=pulse,horizon,swagger,api,livewire
+```
+
 You can safely `.gitignore` the `wayfinder`, `actions`, and `routes` directories as they are completely re-generated on every build.
 
 ## Usage


### PR DESCRIPTION
This PR adds a new option to allow the filtering of routes by uri/name. This is useful for excluding routes that typically won't get used by the frontend anyway, such as horizon, pulse or livewire routes.