### PR TITLE
feat: introduce route utility types for improved DX

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "^10.1"
+        "orchestra/testbench": "10.2.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "10.2.2"
+        "orchestra/testbench": "^10.1 | ^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/resources/function-arguments.blade.ts
+++ b/resources/function-arguments.blade.ts
@@ -23,4 +23,4 @@ args{!! when($parameters->every->optional, '?') !!}: {
 @endif
 ,
 @endif
-options?: { query?: QueryParams, mergeQuery?: QueryParams }
+options?: RouteQueryOptions

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -9,7 +9,7 @@ export type QueryParams = Record<
     | Record<string, string | number | boolean>
 >;
 
-type Method = "get" | "post" | "put" | "delete" | "patch" | "head" | string;
+type Method = "get" | "post" | "put" | "delete" | "patch" | "head";
 
 export type RouteDefinition<TMethod extends Method | Method[]> = {
     url: string;

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -9,10 +9,21 @@ export type QueryParams = Record<
     | Record<string, string | number | boolean>
 >;
 
-export const queryParams = (options?: {
+export type RouteDefinition<TMethod extends string | string[]> = {
+    url: string;
+} & (TMethod extends string[] ? { methods: TMethod } : { method: TMethod });
+
+export type RouteFormDefinition<TMethod extends string> = {
+    action: string;
+    method: TMethod;
+};
+
+export type RouteQueryOptions = {
     query?: QueryParams;
     mergeQuery?: QueryParams;
-}) => {
+}
+
+export const queryParams = (options?: RouteQueryOptions) => {
     if (!options || (!options.query && !options.mergeQuery)) {
         return "";
     }

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -9,11 +9,13 @@ export type QueryParams = Record<
     | Record<string, string | number | boolean>
 >;
 
-export type RouteDefinition<TMethod extends string | string[]> = {
-    url: string;
-} & (TMethod extends string[] ? { methods: TMethod } : { method: TMethod });
+type Method = "get" | "post" | "put" | "delete" | "patch" | "head" | string;
 
-export type RouteFormDefinition<TMethod extends string> = {
+export type RouteDefinition<TMethod extends Method | Method[]> = {
+    url: string;
+} & (TMethod extends Method[] ? { methods: TMethod } : { method: TMethod });
+
+export type RouteFormDefinition<TMethod extends Method> = {
     action: string;
     method: TMethod;
 };

--- a/resources/method.blade.ts
+++ b/resources/method.blade.ts
@@ -1,16 +1,17 @@
 @include('wayfinder::docblock')
-{!! when(($export ?? true) && !$isInvokable, 'export ') !!}const {!! $method !!} = (@include('wayfinder::function-arguments')): {
-    url: string,
-    method: @js($verbs->first()->actual),
-} => ({
+{!! when(($export ?? true) && !$isInvokable, 'export ') !!}const {!! $method !!} = (@include('wayfinder::function-arguments')): RouteDefinition<@js($verbs->first()->actual)> => ({
     url: {!! $method !!}.url({!! when($parameters->isNotEmpty(), 'args, ') !!}options),
     method: @js($verbs->first()->actual),
 })
 
+@php
+    $verbsArray = $verbs->map(fn($verb) => $verb->actual)->join("','");
+@endphp
+
 {!! $method !!}.definition = {
-    methods: [@foreach ($verbs as $verb)@js($verb->actual){!! when(! $loop->last, ',') !!}@endforeach],
+    methods: ['{!! $verbsArray !!}'],
     url: {!! $uri !!},
-}
+} satisfies RouteDefinition<['{!! $verbsArray !!}']>
 
 @include('wayfinder::docblock')
 {!! $method !!}.url = (@include('wayfinder::function-arguments')) => {
@@ -69,10 +70,7 @@
 
 @foreach ($verbs as $verb)
 @include('wayfinder::docblock')
-{!! $method !!}.{!! $verb->actual !!} = (@include('wayfinder::function-arguments')): {
-    url: string,
-    method: @js($verb->actual),
-} => ({
+{!! $method !!}.{!! $verb->actual !!} = (@include('wayfinder::function-arguments')): RouteDefinition<@js($verb->actual)> => ({
     url: {!! $method !!}.url({!! when($parameters->isNotEmpty(), 'args, ') !!}options),
     method: @js($verb->actual),
 })
@@ -80,10 +78,7 @@
 
 @if ($withForm)
     @include('wayfinder::docblock')
-    const {!! $method !!}Form = (@include('wayfinder::function-arguments')): {
-        action: string,
-        method: @js($verbs->first()->formSafe),
-    } => ({
+    const {!! $method !!}Form = (@include('wayfinder::function-arguments')): RouteFormDefinition<@js($verbs->first()->formSafe)> => ({
         action: {!! $method !!}.url(
             {!! when($parameters->isNotEmpty(), 'args, ') !!}
             @if ($verbs->first()->formSafe === $verbs->first()->actual)
@@ -102,10 +97,7 @@
 
     @foreach ($verbs as $verb)
         @include('wayfinder::docblock')
-        {!! $method !!}Form.{!! $verb->actual !!} = (@include('wayfinder::function-arguments')): {
-            action: string,
-            method: @js($verb->formSafe),
-        } => ({
+        {!! $method !!}Form.{!! $verb->actual !!} = (@include('wayfinder::function-arguments')): RouteFormDefinition<@js($verb->formSafe)> => ({
             action: {!! $method !!}.url(
                 {!! when($parameters->isNotEmpty(), 'args, ') !!}
                 @if ($verb->formSafe === $verb->actual)

--- a/resources/method.blade.ts
+++ b/resources/method.blade.ts
@@ -4,14 +4,10 @@
     method: @js($verbs->first()->actual),
 })
 
-@php
-    $verbsArray = $verbs->map(fn($verb) => $verb->actual)->join("','");
-@endphp
-
 {!! $method !!}.definition = {
-    methods: ['{!! $verbsArray !!}'],
+    methods: {!! $verbs->pluck('actual')->toJson() !!},
     url: {!! $uri !!},
-} satisfies RouteDefinition<['{!! $verbsArray !!}']>
+} satisfies RouteDefinition<{!! $verbs->pluck('actual')->toJson() !!}>
 
 @include('wayfinder::docblock')
 {!! $method !!}.url = (@include('wayfinder::function-arguments')) => {

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -222,7 +222,11 @@ class GenerateCommand extends Command
 
     private function appendCommonImports(Collection $routes, string $path, string $namespace): void
     {
-        $imports = ['queryParams', 'type QueryParams'];
+        $imports = ['queryParams', 'type RouteQueryOptions', 'type RouteDefinition'];
+
+        if ($this->option('with-form') === true) {
+            $imports[] = 'type RouteFormDefinition';
+        }
 
         if ($routes->contains(fn (Route $route) => $route->parameters()->contains(fn (Parameter $parameter) => $parameter->optional))) {
             $imports[] = 'validateParameters';


### PR DESCRIPTION
This PR introduces and exports three new utility types:

- `RouteDefinition`
- `RouteFormDefinition`
- `RouteQueryOptions`

### Why?

*   **Enhanced DX:** Allows end-users to import and utilize these types in their projects for better type safety, autocompletion, and easier integration.

    ```typescript
    import type { RouteDefinition } from '@/wayfinder';

    function sendRequest(route: RouteDefinition<'post'>) { /* ... */ }

    sendRequest(StorePostController());
    ```
*   **Cleaner Generated Code:** The generated code now uses these shared types, improving the output's readability.

Thanks 🙏