### PR TITLE
feat: Adds support for providing default URL parameters via the frontend

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -107,7 +107,7 @@ export const addUrlDefault = (
     urlDefaults[key] = value;
 };
 
-export const applyUrlDefaults = (existing: Record<string, unknown>) => {
+export const applyUrlDefaults = <T>(existing: T): T => {
     const existingParams = { ...existing };
 
     for (const key in urlDefaults) {

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -11,16 +11,7 @@ export type QueryParams = Record<
 
 type Method = "get" | "post" | "put" | "delete" | "patch" | "head";
 
-declare global {
-    interface Window {
-        Wayfinder: {
-            defaultParameters: Record<string, unknown>;
-        };
-    }
-}
-window.Wayfinder = {
-    defaultParameters: {},
-};
+let urlDefaults = {};
 
 export type RouteDefinition<TMethod extends Method | Method[]> = {
     url: string;
@@ -106,25 +97,25 @@ export const queryParams = (options?: RouteQueryOptions) => {
 };
 
 export const setUrlDefaults = (params: Record<string, unknown>) => {
-    window.Wayfinder.defaultParameters = params;
+    urlDefaults = params;
 };
 
 export const addUrlDefault = (
     key: string,
     value: string | number | boolean,
 ) => {
-    window.Wayfinder.defaultParameters[key] = value;
+    urlDefaults[key] = value;
 };
 
 export const applyUrlDefaults = (existing: Record<string, unknown>) => {
     const existingParams = { ...existing };
 
-    for (const key in window.Wayfinder.defaultParameters) {
+    for (const key in urlDefaults) {
         if (
             existingParams[key] === undefined &&
-            window.Wayfinder.defaultParameters[key] !== undefined
+            urlDefaults[key] !== undefined
         ) {
-            existingParams[key] = window.Wayfinder.defaultParameters[key];
+            existingParams[key] = urlDefaults[key];
         }
     }
 

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -11,6 +11,17 @@ export type QueryParams = Record<
 
 type Method = "get" | "post" | "put" | "delete" | "patch" | "head";
 
+declare global {
+    interface Window {
+        Wayfinder: {
+            defaultParameters: Record<string, unknown>;
+        };
+    }
+}
+window.Wayfinder = {
+    defaultParameters: {},
+}
+
 export type RouteDefinition<TMethod extends Method | Method[]> = {
     url: string;
 } & (TMethod extends Method[] ? { methods: TMethod } : { method: TMethod });
@@ -85,6 +96,26 @@ export const queryParams = (options?: RouteQueryOptions) => {
     const str = params.toString();
 
     return str.length > 0 ? `?${str}` : "";
+};
+
+export const setDefaultParameters = (params: Record<string, unknown>) => {
+    window.Wayfinder.defaultParameters = params;
+};
+
+export const addDefaultParameter = (key: string, value: string | number | boolean) => {
+    window.Wayfinder.defaultParameters[key] = value;
+};
+
+export const applyDefaultParameters = (existing: Record<string, unknown>) => {
+    const existingParams = { ...existing }
+
+    for (const key in window.Wayfinder.defaultParameters) {
+        if (existingParams[key] === undefined && window.Wayfinder.defaultParameters[key] !== undefined) {
+            existingParams[key] = window.Wayfinder.defaultParameters[key];
+        }
+    }
+
+    return existingParams;
 };
 
 export const validateParameters = (

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -20,7 +20,7 @@ declare global {
 }
 window.Wayfinder = {
     defaultParameters: {},
-}
+};
 
 export type RouteDefinition<TMethod extends Method | Method[]> = {
     url: string;
@@ -34,7 +34,7 @@ export type RouteFormDefinition<TMethod extends Method> = {
 export type RouteQueryOptions = {
     query?: QueryParams;
     mergeQuery?: QueryParams;
-}
+};
 
 export const queryParams = (options?: RouteQueryOptions) => {
     if (!options || (!options.query && !options.mergeQuery)) {
@@ -84,8 +84,15 @@ export const queryParams = (options?: RouteQueryOptions) => {
             });
 
             for (const subKey in query[key]) {
-                if (['string', 'number', 'boolean'].includes(typeof query[key][subKey])) {
-                    params.set(`${key}[${subKey}]`, getValue(query[key][subKey]));
+                if (
+                    ["string", "number", "boolean"].includes(
+                        typeof query[key][subKey],
+                    )
+                ) {
+                    params.set(
+                        `${key}[${subKey}]`,
+                        getValue(query[key][subKey]),
+                    );
                 }
             }
         } else {
@@ -98,19 +105,25 @@ export const queryParams = (options?: RouteQueryOptions) => {
     return str.length > 0 ? `?${str}` : "";
 };
 
-export const setDefaultParameters = (params: Record<string, unknown>) => {
+export const setUrlDefaults = (params: Record<string, unknown>) => {
     window.Wayfinder.defaultParameters = params;
 };
 
-export const addDefaultParameter = (key: string, value: string | number | boolean) => {
+export const addUrlDefault = (
+    key: string,
+    value: string | number | boolean,
+) => {
     window.Wayfinder.defaultParameters[key] = value;
 };
 
-export const applyDefaultParameters = (existing: Record<string, unknown>) => {
-    const existingParams = { ...existing }
+export const applyUrlDefaults = (existing: Record<string, unknown>) => {
+    const existingParams = { ...existing };
 
     for (const key in window.Wayfinder.defaultParameters) {
-        if (existingParams[key] === undefined && window.Wayfinder.defaultParameters[key] !== undefined) {
+        if (
+            existingParams[key] === undefined &&
+            window.Wayfinder.defaultParameters[key] !== undefined
+        ) {
             existingParams[key] = window.Wayfinder.defaultParameters[key];
         }
     }

--- a/resources/method.blade.ts
+++ b/resources/method.blade.ts
@@ -31,7 +31,8 @@
         @endforeach
         }
     }
-    args = applyDefaultParameters(args)
+
+    args = applyUrlDefaults(args)
 @endif
 
 @if ($parameters->where('optional')->isNotEmpty())

--- a/resources/method.blade.ts
+++ b/resources/method.blade.ts
@@ -31,6 +31,7 @@
         @endforeach
         }
     }
+    args = applyDefaultParameters(args)
 @endif
 
 @if ($parameters->where('optional')->isNotEmpty())

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -229,7 +229,7 @@ class GenerateCommand extends Command
         }
 
         if ($routes->contains(fn (Route $route) => $route->parameters()->isNotEmpty())) {
-            $imports[] = 'applyDefaultParameters';
+            $imports[] = 'applyUrlDefaults';
         }
 
         if ($routes->contains(fn (Route $route) => $route->parameters()->contains(fn (Parameter $parameter) => $parameter->optional))) {

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -55,7 +55,7 @@ class GenerateCommand extends Command
         $this->forcedScheme = (new ReflectionProperty($this->url, 'forceScheme'))->getValue($this->url);
         $this->forcedRoot = (new ReflectionProperty($this->url, 'forcedRoot'))->getValue($this->url);
 
-        $globalUrlDefaults = collect(URL::getDefaultParameters())->filter(fn ($v) => is_scalar($v) || is_null($v));
+        $globalUrlDefaults = collect(URL::getDefaultParameters())->map(fn ($v) => is_scalar($v) || is_null($v) ? $v : '');
 
         $routes = collect($this->router->getRoutes())->map(function (BaseRoute $route) use ($globalUrlDefaults) {
             $defaults = collect($this->router->gatherRouteMiddleware($route))->map(function ($middleware) {

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Route as BaseRoute;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\View\Factory;
 use ReflectionProperty;
@@ -54,7 +55,9 @@ class GenerateCommand extends Command
         $this->forcedScheme = (new ReflectionProperty($this->url, 'forceScheme'))->getValue($this->url);
         $this->forcedRoot = (new ReflectionProperty($this->url, 'forcedRoot'))->getValue($this->url);
 
-        $routes = collect($this->router->getRoutes())->map(function (BaseRoute $route) {
+        $globalUrlDefaults = collect(URL::getDefaultParameters())->filter(fn ($v) => is_scalar($v) || is_null($v));
+
+        $routes = collect($this->router->getRoutes())->map(function (BaseRoute $route) use ($globalUrlDefaults) {
             $defaults = collect($this->router->gatherRouteMiddleware($route))->map(function ($middleware) {
                 if ($middleware instanceof \Closure) {
                     return [];
@@ -65,7 +68,7 @@ class GenerateCommand extends Command
                 return $this->urlDefaults[$middleware];
             })->flatMap(fn ($r) => $r);
 
-            return new Route($route, $defaults, $this->forcedScheme, $this->forcedRoot);
+            return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot);
         });
 
         if (! $this->option('skip-actions')) {
@@ -344,6 +347,12 @@ class GenerateCommand extends Command
         }
 
         $methodContents = str($methodContents)->after('{')->beforeLast('}')->trim();
+
+        return $this->extractUrlDefaults($methodContents);
+    }
+
+    private function extractUrlDefaults(string $methodContents): array
+    {
         $tokens = token_get_all('<?php '.$methodContents);
         $foundUrlFacade = false;
         $defaults = [];

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -228,6 +228,10 @@ class GenerateCommand extends Command
             $imports[] = 'type RouteFormDefinition';
         }
 
+        if ($routes->contains(fn (Route $route) => $route->parameters()->isNotEmpty())) {
+            $imports[] = 'applyDefaultParameters';
+        }
+
         if ($routes->contains(fn (Route $route) => $route->parameters()->contains(fn (Parameter $parameter) => $parameter->optional))) {
             $imports[] = 'validateParameters';
         }

--- a/tests/DefaultParameters.test.ts
+++ b/tests/DefaultParameters.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "vitest";
 import {
     defaultParametersDomain,
-    dynamicDomain,
     fixedDomain,
 } from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
 import { setUrlDefaults } from "../workbench/resources/js/wayfinder";
@@ -10,18 +9,6 @@ test("it can generate urls without default parameters set", () => {
     expect(fixedDomain.url({ param: "foo" })).toBe(
         "//example.test/fixed-domain/foo",
     );
-});
-
-test("it can generate urls with default parameters set on frontend", () => {
-    setUrlDefaults({
-        domain: "tim.macdonald",
-    });
-
-    expect(
-        dynamicDomain.url({
-            param: "foo",
-        }),
-    ).toBe("//tim.macdonald.au/dynamic-domain/foo");
 });
 
 test("it can generate urls with default URL parameters set on backend and frontend", () => {

--- a/tests/DefaultParameters.test.ts
+++ b/tests/DefaultParameters.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest";
+import { defaultParametersDomain, dynamicDomain, fixedDomain } from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
+import { setDefaultParameters } from "../resources/js/wayfinder";
+
+test('it can generate urls without default parameters set', () => {
+    expect(fixedDomain.url({ param: 'foo' })).toBe('//example.test/fixed-domain/foo')
+})
+
+test('it can generate urls with default parameters set on frontend', () => {
+    setDefaultParameters({
+        domain: 'tim.macdonald',
+    })
+
+    expect(dynamicDomain.url({
+        param: 'foo',
+    })).toBe('//tim.macdonald.au/dynamic-domain/foo')
+})
+
+test('it can generate urls with default URL parameters set on backend and frontend', () => {
+    setDefaultParameters({
+        defaultDomain: 'tim.macdonald',
+    })
+
+    expect(defaultParametersDomain.url({
+        param: 'foo',
+    })).toBe('//tim.macdonald.au/default-parameters-domain/foo')
+})

--- a/tests/DefaultParameters.test.ts
+++ b/tests/DefaultParameters.test.ts
@@ -1,27 +1,37 @@
 import { expect, test } from "vitest";
-import { defaultParametersDomain, dynamicDomain, fixedDomain } from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
-import { setDefaultParameters } from "../resources/js/wayfinder";
+import { setUrlDefaults } from "../resources/js/wayfinder";
+import {
+    defaultParametersDomain,
+    dynamicDomain,
+    fixedDomain,
+} from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
 
-test('it can generate urls without default parameters set', () => {
-    expect(fixedDomain.url({ param: 'foo' })).toBe('//example.test/fixed-domain/foo')
-})
+test("it can generate urls without default parameters set", () => {
+    expect(fixedDomain.url({ param: "foo" })).toBe(
+        "//example.test/fixed-domain/foo",
+    );
+});
 
-test('it can generate urls with default parameters set on frontend', () => {
-    setDefaultParameters({
-        domain: 'tim.macdonald',
-    })
+test("it can generate urls with default parameters set on frontend", () => {
+    setUrlDefaults({
+        domain: "tim.macdonald",
+    });
 
-    expect(dynamicDomain.url({
-        param: 'foo',
-    })).toBe('//tim.macdonald.au/dynamic-domain/foo')
-})
+    expect(
+        dynamicDomain.url({
+            param: "foo",
+        }),
+    ).toBe("//tim.macdonald.au/dynamic-domain/foo");
+});
 
-test('it can generate urls with default URL parameters set on backend and frontend', () => {
-    setDefaultParameters({
-        defaultDomain: 'tim.macdonald',
-    })
+test("it can generate urls with default URL parameters set on backend and frontend", () => {
+    setUrlDefaults({
+        defaultDomain: "tim.macdonald",
+    });
 
-    expect(defaultParametersDomain.url({
-        param: 'foo',
-    })).toBe('//tim.macdonald.au/default-parameters-domain/foo')
-})
+    expect(
+        defaultParametersDomain.url({
+            param: "foo",
+        }),
+    ).toBe("//tim.macdonald.au/default-parameters-domain/foo");
+});

--- a/tests/DefaultParameters.test.ts
+++ b/tests/DefaultParameters.test.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "vitest";
-import { setUrlDefaults } from "../resources/js/wayfinder";
 import {
     defaultParametersDomain,
     dynamicDomain,
     fixedDomain,
 } from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
+import { setUrlDefaults } from "../workbench/resources/js/wayfinder";
 
 test("it can generate urls without default parameters set", () => {
     expect(fixedDomain.url({ param: "foo" })).toBe(

--- a/tests/DomainController.test.ts
+++ b/tests/DomainController.test.ts
@@ -1,13 +1,20 @@
 import { expect, test } from "vitest";
-import { dynamicDomain, fixedDomain } from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
+import {
+    defaultParametersDomain,
+    fixedDomain,
+} from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
 
-test('can generate fixed domain urls', () => {
-    expect(fixedDomain.url({ param: 'foo' })).toBe('//example.test/fixed-domain/foo')
-})
+test("can generate fixed domain urls", () => {
+    expect(fixedDomain.url({ param: "foo" })).toBe(
+        "//example.test/fixed-domain/foo",
+    );
+});
 
-test('can generate dynamic domain urls', () => {
-    expect(dynamicDomain.url({
-        domain: 'tim.macdonald',
-        param: 'foo',
-    })).toBe('//tim.macdonald.au/dynamic-domain/foo')
-})
+test("can generate dynamic domain urls", () => {
+    expect(
+        defaultParametersDomain.url({
+            defaultDomain: "tim.macdonald",
+            param: "foo",
+        }),
+    ).toBe("//tim.macdonald.au/default-parameters-domain/foo");
+});

--- a/workbench/app/Http/Controllers/DomainController.php
+++ b/workbench/app/Http/Controllers/DomainController.php
@@ -13,4 +13,9 @@ class DomainController
     {
         //
     }
+
+    public function defaultParametersDomain()
+    {
+        //
+    }
 }

--- a/workbench/app/Http/Controllers/DomainController.php
+++ b/workbench/app/Http/Controllers/DomainController.php
@@ -9,11 +9,6 @@ class DomainController
         //
     }
 
-    public function dynamicDomain()
-    {
-        //
-    }
-
     public function defaultParametersDomain()
     {
         //

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class WorkbenchServiceProvider extends ServiceProvider
@@ -19,6 +20,10 @@ class WorkbenchServiceProvider extends ServiceProvider
                 'serve' => true,
                 'throw' => false,
             ],
+        ]);
+
+        URL::defaults([
+            'defaultDomain' => 'tim.macdonald',
         ]);
     }
 

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -59,6 +59,7 @@ Route::get('/parameter-names/{SCREAMING_SNAKE_CASE}/screaming-snake', [Parameter
 
 Route::domain('example.test')->get('/fixed-domain/{param}', [DomainController::class, 'fixedDomain']);
 Route::domain('{domain}.au')->get('/dynamic-domain/{param}', [DomainController::class, 'dynamicDomain']);
+Route::domain('{defaultDomain}.au')->get('/default-parameters-domain/{param}', [DomainController::class, 'defaultParametersDomain']);
 
 Route::get('/nested/controller', [NestedController::class, 'nested']);
 

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -58,7 +58,6 @@ Route::get('/parameter-names/{snake_case}/snake', [ParameterNameController::clas
 Route::get('/parameter-names/{SCREAMING_SNAKE_CASE}/screaming-snake', [ParameterNameController::class, 'screamingSnake']);
 
 Route::domain('example.test')->get('/fixed-domain/{param}', [DomainController::class, 'fixedDomain']);
-Route::domain('{domain}.au')->get('/dynamic-domain/{param}', [DomainController::class, 'dynamicDomain']);
 Route::domain('{defaultDomain}.au')->get('/default-parameters-domain/{param}', [DomainController::class, 'defaultParametersDomain']);
 
 Route::get('/nested/controller', [NestedController::class, 'nested']);


### PR DESCRIPTION
This should resolve #49 

This PR adds support for providing default URL values during runtime via the frontend. This works by providing methods within the `wayfinder.ts` that user-land code can call to set (or add individual) default parameters. These parameters are stored in a global `Wayfinder` window object. 

When generating the URL for a controller, we merge in any set default parameters, making sure that we don't override any keys already set during the calling of the `url` method.

Note: in theory we don't need to use a window object here, but when running the test suite, it seems like I was getting different instances of the `wayfinder.ts` file, the default parameters that were set were getting lost.

## Usage

Here's how I have it set up in our app. The benefit here is it is up to the user to decide where and when to apply the defaults:

```tsx
  setup({ el, App, props }) {
    const root = createRoot(el);

    setDefaultParameters({
      workspace: props.initialPage.props.workspace.slug
    });

    root.render(<App {...props} />);
  },
```

---

One thing I have not figured out with this approach is non-optional parameters that do not have a default set via the URL facade on the backend. Wayfinder doesn't know that `domain` parameter is being set as a default and will be applied/set during the `url()` call:

<img width="695" height="379" alt="Screenshot 2025-08-01 at 8 42 53 AM" src="https://github.com/user-attachments/assets/5a3d5cce-88b5-40ca-9a2a-4f063b29107e" />