### PR TITLE
Add compatibility with strictNullChecks

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -73,6 +73,10 @@ export const queryParams = (options?: RouteQueryOptions) => {
             });
 
             for (const subKey in query[key]) {
+                if (typeof query[key][subKey] === 'undefined') {
+                    continue;
+                }
+
                 if (['string', 'number', 'boolean'].includes(typeof query[key][subKey])) {
                     params.set(`${key}[${subKey}]`, getValue(query[key][subKey]));
                 }


### PR DESCRIPTION
This PR adds compatibility with the TSConfig option `strictNullChecks`. This is accomplished with a simple type guard when mapping over `subKey`s to ensure it's not undefined.

Without this, Wayfinder makes projects that use `strictNullChecks` fail type checking.