### PR TITLE
fix: Add missing "options" to `Method` type

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -9,7 +9,7 @@ export type QueryParams = Record<
     | Record<string, string | number | boolean>
 >;
 
-type Method = "get" | "post" | "put" | "delete" | "patch" | "head";
+type Method = "get" | "post" | "put" | "delete" | "patch" | "head" | "options";
 
 let urlDefaults: Record<string, unknown> = {};
 


### PR DESCRIPTION
Some of the type errors from #77 did not get fixed with 0.1.8, but this PR should fix the remaining errors by adding the missing `"options"` to the `Method` type.

These are the errors fixed by this PR:

```

> types
> tsc --noEmit

resources/js/actions/Illuminate/Routing/RedirectController.ts:13:5 - error TS2561: Object literal may only specify known properties, but 'methods' does not exist in type 'RouteDefinition<["get", "head", "post", "put", "patch", "delete", "options"]>'. Did you mean to write 'method'?

13     methods: ["get","head","post","put","patch","delete","options"],
       ~~~~~~~

resources/js/actions/Illuminate/Routing/RedirectController.ts:15:29 - error TS2344: Type '["get", "head", "post", "put", "patch", "delete", "options"]' does not satisfy the constraint 'Method | Method[]'.
  Type '["get", "head", "post", "put", "patch", "delete", "options"]' is not assignable to type 'Method[]'.
    Type '"get" | "post" | "put" | "delete" | "patch" | "head" | "options"' is not assignable to type 'Method'.
      Type '"options"' is not assignable to type 'Method'.

15 } satisfies RouteDefinition<["get","head","post","put","patch","delete","options"]>
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

resources/js/actions/Illuminate/Routing/RedirectController.ts:85:77 - error TS2344: Type '"options"' does not satisfy the constraint 'Method | Method[]'.

85 RedirectController.options = (options?: RouteQueryOptions): RouteDefinition<'options'> => ({
                                                                               ~~~~~~~~~


Found 3 errors in the same file, starting at: resources/js/actions/Illuminate/Routing/RedirectController.ts:13
```