### PR TITLE
Add Postgres default int4 type to the number map

### DIFF
--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -51,6 +51,7 @@ class Parameter
                 'int',
                 'integer',
                 'bigint',
+                'int4',
                 'int8',
                 'serial',
                 'bigserial',


### PR DESCRIPTION
The `integer` column type in postgres is a [4 byte column by default](https://www.postgresql.org/docs/current/datatype-numeric.html), which is not currently mapped to the Number typescript type. This column would result from invoking `$table->integer('foo');` in a laravel migration.

```
Schema::create('characters', function (Blueprint $table): void {
    ...
    $table->integer('character_id')->unique();
    ...
});
```

Test script
```
<?php

declare(strict_types=1);

$model = new \App\Models\Character();

$table = $model->getConnection()
    ->getSchemaBuilder()
    ->getColumns($model->getTable());

dd($table);
```
Which outputs
```
Other Columns...
2 => array:9 [
    "name" => "character_id"
    "type_name" => "int4"
    "type" => "integer"
    "collation" => null
    "nullable" => false
    "default" => null
    "auto_increment" => false
    "comment" => null
    "generation" => null
  ]
Other Columns...
```