### PR TITLE
fix: export named routes for invokable controllers

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -260,7 +260,7 @@ class GenerateCommand extends Command
             'method' => $route->namedMethod(),
             'original_method' => $route->originalJsMethod(),
             'isInvokable' => $route->hasInvokableController(),
-            'shouldExport' => ! $route->hasInvokableController() || str_contains($route->controller(), '\\Closure'),
+            'shouldExport' => true,
             'path' => $route->controllerPath(),
             'line' => $route->controllerMethodLineNumber(),
             'parameters' => $route->parameters(),

--- a/tests/NamedRoutes.test.ts
+++ b/tests/NamedRoutes.test.ts
@@ -1,10 +1,23 @@
 import { expect, it } from "vitest";
 import { edit } from "../workbench/resources/js/routes/posts";
+import { invokable, dashboard } from "../workbench/resources/js/routes";
 
 it("exports named routes", () => {
     expect(edit.url(1)).toBe("/posts/1/edit");
     expect(edit(1)).toEqual({
         url: "/posts/1/edit",
+        method: "get",
+    });
+
+    expect(dashboard.url()).toBe("/dashboard")
+    expect(dashboard()).toEqual({
+        url: "/dashboard",
+        method: "get",
+    });
+
+    expect(invokable.url()).toBe("/invokable-controller")
+    expect(invokable()).toEqual({
+        url: "/invokable-controller",
         method: "get",
     });
 });

--- a/tests/NamedRoutes.test.ts
+++ b/tests/NamedRoutes.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest";
+import { dashboard, invokable } from "../workbench/resources/js/routes";
 import { edit } from "../workbench/resources/js/routes/posts";
-import { invokable, dashboard } from "../workbench/resources/js/routes";
 
 it("exports named routes", () => {
     expect(edit.url(1)).toBe("/posts/1/edit");
@@ -9,15 +9,15 @@ it("exports named routes", () => {
         method: "get",
     });
 
-    expect(dashboard.url()).toBe("/dashboard")
+    expect(dashboard.url()).toBe("/dashboard");
     expect(dashboard()).toEqual({
         url: "/dashboard",
         method: "get",
     });
 
-    expect(invokable.url()).toBe("/invokable-controller")
+    expect(invokable.url()).toBe("/named-invokable-controller");
     expect(invokable()).toEqual({
-        url: "/invokable-controller",
+        url: "/named-invokable-controller",
         method: "get",
     });
 });

--- a/workbench/app/Http/Controllers/NamedInvokableController.php
+++ b/workbench/app/Http/Controllers/NamedInvokableController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class NamedInvokableController
+{
+    public function __invoke()
+    {
+        //
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\InvokableController;
 use App\Http\Controllers\InvokablePlusController;
 use App\Http\Controllers\KeyController;
 use App\Http\Controllers\ModelBindingController;
+use App\Http\Controllers\NamedInvokableController;
 use App\Http\Controllers\Nested\NestedController;
 use App\Http\Controllers\OptionalController;
 use App\Http\Controllers\ParameterNameController;
@@ -21,7 +22,8 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('/closure', fn () => 'ok');
-Route::get('/invokable-controller', InvokableController::class)->name('invokable');
+Route::get('/invokable-controller', InvokableController::class);
+Route::get('/named-invokable-controller', NamedInvokableController::class)->name('invokable');
 Route::get('/invokable-plus-controller', InvokablePlusController::class);
 Route::post('/invokable-plus-controller', [InvokablePlusController::class, 'store']);
 

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -21,7 +21,7 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('/closure', fn () => 'ok');
-Route::get('/invokable-controller', InvokableController::class);
+Route::get('/invokable-controller', InvokableController::class)->name('invokable');
 Route::get('/invokable-plus-controller', InvokablePlusController::class);
 Route::post('/invokable-plus-controller', [InvokablePlusController::class, 'store']);
 


### PR DESCRIPTION
Fixes #83 

---

Named routes with invokable controllers were not being exported correctly.

```php
Route::get('/test', InvokableController::class)
    ->name('test');
```