### PR TITLE
Fix TypeScript reserved keyword parameters in array syntax

### DIFF
--- a/resources/function-arguments.blade.ts
+++ b/resources/function-arguments.blade.ts
@@ -10,7 +10,7 @@ args{!! when($parameters->every->optional, '?') !!}: {
 
 | [
     @foreach ($parameters as $parameter)
-        {{ $parameter->name }}: {!! $parameter->types !!}
+        {{ $parameter->safeName() }}: {!! $parameter->types !!}
         @if ($parameter->key)
             | { {!! $parameter->key !!}: {!! $parameter->types !!} }
          @endif

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -73,4 +73,9 @@ class Parameter
 
         return 'string';
     }
+
+    public function safeName(): string
+    {
+        return TypeScript::safeMethod($this->name, 'Param');
+    }
 }

--- a/tests/Export.test.ts
+++ b/tests/Export.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "vitest";
+import { exportMethod } from "../workbench/resources/js/routes/index";
+
+test("export param", () => {
+    expect(exportMethod.url({ report: "a", export: "b" })).toBe("/export/a/b");
+    expect(exportMethod.url(["a", "b"])).toBe("/export/a/b");
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -22,7 +22,7 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('/closure', fn () => 'ok');
-Route::get('/export/{export}', fn () => 'Export')->name('export');
+Route::get('/export/{report}/{export}', fn () => 'Export')->name('export');
 Route::get('/invokable-controller', InvokableController::class);
 Route::get('/named-invokable-controller', NamedInvokableController::class)->name('invokable');
 Route::get('/invokable-plus-controller', InvokablePlusController::class);


### PR DESCRIPTION
One my routes has an `{export}` parameter, which is a reserved word.

In the object, this is not a problem:

```ts
{ report: string | number, export: string | number }
```

But in the array/tuple, it breaks:

```ts
[report: string | number, export: string | number ]
```

I'm not sure this is the right solution, but it now appends `Param` to params that are reserved words:

```ts
exportMethod.url = (args: { report: string | number, export: string | number } | [report: string | number, exportParam: string | number ], options?: RouteQueryOptions) => {
  // ...
}