### PR TITLE
Improve readability of QueryParams union formatting

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -1,5 +1,5 @@
 export type QueryParams = Record<
-    string,
+    | string,
     | string
     | number
     | boolean


### PR DESCRIPTION
This pull request improves the readability of the QueryParams type definition in resources/js/wayfinder.ts by reformatting its union types.

Specifically, the union members are now aligned vertically with a leading |, which is a common TypeScript style convention. This approach makes the type definition easier to scan, reduces visual clutter, and simplifies future edits (e.g., adding or removing types with cleaner diffs).