### PR TITLE
Parse model dockblocks as a fallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "illuminate/console": "^11.0|^12.0",
         "illuminate/filesystem": "^11.0|^12.0",
         "illuminate/routing": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/support": "^11.0|^12.0",
+        "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {
         "laravel/pint": "^1.21",

--- a/src/BindingResolver.php
+++ b/src/BindingResolver.php
@@ -3,12 +3,26 @@
 namespace Laravel\Wayfinder;
 
 use Illuminate\Database\Eloquent\Model;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
+use ReflectionClass;
+use Throwable;
 
 class BindingResolver
 {
     protected static $booted = [];
 
     protected static $columns = [];
+
+    protected static ?PhpDocParser $docParser = null;
+
+    protected static ?Lexer $lexer = null;
 
     public static function resolveTypeAndKey(string $routable, $key): array
     {
@@ -20,7 +34,7 @@ class BindingResolver
             return [null, $key];
         }
 
-        self::$columns[$routable] ??= $booted->getConnection()->getSchemaBuilder()->getColumns($booted->getTable());
+        self::$columns[$routable] ??= self::getColumns($booted);
 
         return [
             collect(self::$columns[$routable])->first(
@@ -28,5 +42,68 @@ class BindingResolver
             )['type_name'] ?? null,
             $key,
         ];
+    }
+
+    protected static function getColumns(Model $model): array
+    {
+        try {
+            return $model->getConnection()->getSchemaBuilder()->getColumns($model->getTable());
+        } catch (Throwable) {
+            return self::parseDocBlock($model);
+        }
+    }
+
+    protected static function parseDocBlock(Model $model): array
+    {
+        $doc = (new ReflectionClass($model))->getDocComment();
+
+        if (! $doc) {
+            return [];
+        }
+
+        self::$docParser ??= self::initDocParser();
+        self::$lexer ??= self::initLexer();
+
+        $tokens = new TokenIterator(self::$lexer->tokenize($doc));
+        $phpDocNode = self::$docParser->parse($tokens);
+
+        $tags = array_merge($phpDocNode->getPropertyTagValues(), $phpDocNode->getPropertyReadTagValues(), $phpDocNode->getPropertyWriteTagValues());
+
+        return collect($tags)->map(function ($tag) {
+            $type = $tag->type;
+
+            $typeName = match (true) {
+                $type instanceof IdentifierTypeNode => $type->name,
+                $type instanceof UnionTypeNode => collect($type->types)->filter(fn ($t) => $t instanceof IdentifierTypeNode)->filter(fn ($t) => $t->name !== 'null')->map(fn ($t) => $t->name)->join('|'),
+                default => 'mixed',
+            };
+
+            return [
+                'name' => ltrim($tag->propertyName, '$'),
+                'type_name' => $typeName,
+            ];
+        })->filter()->values()->all();
+    }
+
+    protected static function initDocParser(): PhpDocParser
+    {
+        $config = self::getParserConfig();
+        $constExprParser = new ConstExprParser($config);
+        $typeParser = new TypeParser($config, $constExprParser);
+        $phpDocParser = new PhpDocParser($config, $typeParser, $constExprParser);
+
+        return $phpDocParser;
+    }
+
+    protected static function initLexer(): Lexer
+    {
+        $config = self::getParserConfig();
+
+        return new Lexer($config);
+    }
+
+    protected static function getParserConfig(): ParserConfig
+    {
+        return new ParserConfig(usedAttributes: []);
     }
 }

--- a/tests/ModelBindingController.test.ts
+++ b/tests/ModelBindingController.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "vitest";
+import { show } from "../workbench/resources/js/actions/App/Http/Controllers/ModelBindingController";
+
+test("will detect model binding", () => {
+    expect(show.url(1)).toBe("/users/1");
+    expect(show.url({ user: 1 })).toBe("/users/1");
+    expect(show.url([1])).toBe("/users/1");
+});

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -7,6 +7,16 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property string $password
+ * @property string|null $remember_token
+ * @property \Illuminate\Support\Carbon|null $email_verified_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
 class User extends Authenticatable
 {
     use HasFactory, Notifiable;

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -47,7 +47,7 @@ Route::get('/', function () {
 Route::post('/optional/{parameter?}', [OptionalController::class, 'optional'])->name('optional');
 Route::post('/many-optional/{one?}/{two?}/{three?}', [OptionalController::class, 'manyOptional']);
 
-Route::post('/users/{user}', [ModelBindingController::class, 'show']);
+Route::get('/users/{user}', [ModelBindingController::class, 'show']);
 
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}', [UrlDefaultsController::class, 'onlyDefaults']);
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}/also/{timezone}', [UrlDefaultsController::class, 'mixedDefaults']);


### PR DESCRIPTION
Wayfinder will now parse Eloquent model docblocks as fallback when there isn't a database connection or when the database connection throws an error.

```php
/**
 * @property int $id
 * @property string $name
 * @property string $email
 * @property string $password
 * @property string|null $remember_token
 * @property \Illuminate\Support\Carbon|null $email_verified_at
 * @property \Illuminate\Support\Carbon|null $created_at
 * @property \Illuminate\Support\Carbon|null $updated_at
 */
class User extends Authenticatable
{
    //
}
```

Fixes https://github.com/laravel/wayfinder/issues/59