### PR TITLE
fix: improve domain method to handle forcedRoot and return cleaned URL

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -119,7 +119,15 @@ class Route
 
     public function domain(): ?string
     {
-        return $this->base->getDomain() ?? $this->forcedRoot;
+        if ($this->base->getDomain()) {
+            return $this->base->getDomain();
+        }
+
+        if ($this->forcedRoot) {
+            return str_replace(['http://', 'https://'], '', $this->forcedRoot);
+        }
+
+        return null;
     }
 
     public function name(): ?string


### PR DESCRIPTION
### Fix: incorrect URLs when `forceRoot` is set

When `forceRoot` was used, `Route::domain()` returned the full root including the scheme. Since `uri()` prepends the scheme separately, this resulted in broken URLs like `https://https//site.com/...`, especially when `forceScheme` was also applied.

This change makes `domain()` return only the host part of `forcedRoot` (without `http://` or `https://`). That way, combining it with `scheme()` produces a valid URL.

This also fixes the issue reported in Issue #102 