### PR TITLE
Prevent route export name conflict using hash suffix

### DIFF
--- a/src/TypeScript.php
+++ b/src/TypeScript.php
@@ -98,7 +98,6 @@ class TypeScript
             '} )' => '})',
             ' )' => ')',
             '( ' => '(',
-            '( ' => '(',
             PHP_EOL.' +' => ' +',
             '})'.PHP_EOL.'/**' => '})'.PHP_EOL.PHP_EOL.'/**',
             '}'.PHP_EOL.'/**' => '}'.PHP_EOL.PHP_EOL.'/**',

--- a/tests/NestedController.test.ts
+++ b/tests/NestedController.test.ts
@@ -1,9 +1,11 @@
 import { expect, it } from "vitest";
 import nested from "../workbench/resources/js/routes/nested";
+import Nested from "../workbench/resources/js/actions/App/Http/Controllers/Nested";
 
 it("can handle conflicting nested route names", () => {
     expect(nested.child().url).toBe("/nested/controller/child");
     expect(nested.child.grandchild().url).toBe(
         "/nested/controller/child/grandchild",
     );
+    expect(Nested.Nested.nested().url).toBe("/nested");
 });

--- a/workbench/app/Http/Controllers/Nested/Nested.php
+++ b/workbench/app/Http/Controllers/Nested/Nested.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\Nested;
+
+class Nested
+{
+    public function nested()
+    {
+        //
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\InvokablePlusController;
 use App\Http\Controllers\KeyController;
 use App\Http\Controllers\ModelBindingController;
 use App\Http\Controllers\NamedInvokableController;
+use App\Http\Controllers\Nested\Nested;
 use App\Http\Controllers\Nested\NestedController;
 use App\Http\Controllers\OptionalController;
 use App\Http\Controllers\ParameterNameController;
@@ -63,6 +64,7 @@ Route::get('/parameter-names/{SCREAMING_SNAKE_CASE}/screaming-snake', [Parameter
 Route::domain('example.test')->get('/fixed-domain/{param}', [DomainController::class, 'fixedDomain']);
 Route::domain('{defaultDomain}.au')->get('/default-parameters-domain/{param}', [DomainController::class, 'defaultParametersDomain']);
 
+Route::get('/nested', [Nested::class, 'nested']);
 Route::get('/nested/controller', [NestedController::class, 'nested']);
 Route::get('/nested/controller/child', [NestedController::class, 'child'])->name('nested.child');
 Route::get('/nested/controller/child/grandchild', [NestedController::class, 'grandchild'])->name('nested.child.grandchild');


### PR DESCRIPTION
Fix #97
Fix #101

This pr close 2 issue which pointing to the same problem of nested route or action name conflict

Make new `Nested.php` and route for creating same scenario as this two issues.

Add test into `NestedController.test.ts` - which import nested from `Nested/index.ts` not from direcly `Nested/Nested.ts` file so we can check conflict in test.

Remove duplicate replacements in `cleanUp` funtion of `Typescript.php` file.