### PR TITLE
Add caching support to Wayfinder route generation

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -158,35 +158,6 @@ class Route
         return $this->relativePath((new ReflectionClass($controller))->getFileName());
     }
 
-    public function controllerAbsolutePath(): string
-    {
-        $controller = $this->controller();
-        if ($controller === '\\Closure') {
-            return (new ReflectionClosure($this->closure()))->getFileName();
-        }
-
-        return (new ReflectionClass($controller))->getFileName();
-    }
-
-    public function cacheKey()
-    {
-        $routeName = $this->name();
-        $controllerPath = $this->controllerPath();
-
-        return hash('xxh128', $routeName.$controllerPath);
-    }
-
-    public function cacheValue(): string
-    {
-        $controller = hash_file('xxh128', $this->controllerAbsolutePath());
-        $uri = $this->uri();
-        $methods = json_encode($this->base->methods());
-        $parameters = json_encode($this->parameters());
-        $hash = hash('xxh128', $controller.$uri.$parameters.$methods);
-
-        return $hash;
-    }
-
     public function controllerMethodLineNumber(): int
     {
         $controller = $this->controller();


### PR DESCRIPTION
### Summary

Introduces a basic caching mechanism to prevent unnecessary regeneration of route/action files when nothing has changed.
This avoids deleting and rewriting hundreds of files (500+) on each run which can cause VS Code to lag or crash on Linux systems and significantly improves performance.

### Changes

**_src/Route.php:_**

Added `controllerAbsolutePath()`, `cacheKey()`, and `cacheValue()` for unique cache keys and content hashes.

**_src/GenerateCommand.php:_**

Added `$cached` and `$generatedFiles` arrays to track file generation.
Writes two new cache files:
`cache.json` — stores route-level cache data.
`generated_files.json `— tracks all generated files.