### PR TITLE
[#132] Adds the ability to type Model Attributes

### DIFF
--- a/src/Converters/Models.php
+++ b/src/Converters/Models.php
@@ -2,15 +2,22 @@
 
 namespace Laravel\Wayfinder\Converters;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Support\Str;
 use Laravel\Ranger\Components\Model;
 use Laravel\Wayfinder\Langs\TypeScript;
+use ReflectionClass;
+use ReflectionMethod;
 
 class Models extends Converter
 {
     public function convert(Model $model): null
     {
-        $properties = array_merge($model->getAttributes(), $model->getRelations());
+        $properties = array_merge(
+            $model->getAttributes(),
+            $model->getRelations(),
+            $this->getComputedAttributes($model),
+        );
 
         if ($model->snakeCaseAttributes()) {
             $properties = collect($properties)->mapWithKeys(
@@ -29,5 +36,41 @@ class Models extends Converter
         );
 
         return null;
+    }
+
+    private function getComputedAttributes(Model $model): array
+    {
+        $reflection = new ReflectionClass($model->name);
+
+        return collect($reflection->getMethods(ReflectionMethod::IS_PROTECTED))
+            ->filter(fn (ReflectionMethod $method) => $method->getNumberOfParameters() === 0)
+            ->filter(function (ReflectionMethod $method) {
+                $type = $method->getReturnType();
+
+                return $type
+                    && ! $type->isBuiltin()
+                    && $type->getName() === Attribute::class;
+            })
+            ->mapWithKeys(function (ReflectionMethod $method) {
+                return [
+                    Str::snake($method->getName()) => $this->inferAttributeType($method),
+                ];
+            })
+            ->all();
+    }
+
+    private function inferAttributeType(ReflectionMethod $method): string
+    {
+        $doc = $method->getDocComment();
+
+        if ($doc && preg_match('/@return\s+Attribute<([^>]+)>/', $doc, $matches)) {
+            $types = explode('|', $matches[1]);
+
+            return collect($types)
+                ->map(fn ($type) => TypeScript::fromPhpType(trim($type)))
+                ->implode(' | ');
+        }
+
+        return 'unknown';
     }
 }

--- a/tests/Models.test.ts
+++ b/tests/Models.test.ts
@@ -19,6 +19,16 @@ describe("Models", () => {
         expect(content).toContain("export type User");
     });
 
+    test("User model includes Attribute-based computed property", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toMatch(/formatted_name:\s*string/);
+    });
+
+    test("User model includes Attribute-based computed property", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toMatch(/without_doc:\s*unknown/);
+    });
+
     test.skip("User model types directory exists", () => {
         const userTypesPath = join(
             __dirname,

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -57,6 +59,23 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    /**
+     * @return Attribute<string>
+     */
+    protected function formattedName(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => 'User: '.$this->name,
+        );
+    }
+
+    protected function withoutDoc(): Attribute
+    {
+        return Attribute::make(
+            get: fn (): string => 'without doc',
+        );
+    }
 
     /**
      * @return HasMany<Product, $this>


### PR DESCRIPTION
Uses the type defined within the phpdoc `Attribute<string>` to determine the type of the returned attribute property.