### PR TITLE
[dev-next] Adds collision checks for Routes using the same Component generating duplicate Inertia typescript definitions

### DIFF
--- a/src/Langs/TypeScript.php
+++ b/src/Langs/TypeScript.php
@@ -266,9 +266,15 @@ class TypeScript
 
         $path = str($path)->ltrim('/\\')->replace(['\\', '/'], '.')->toString();
 
-        $block = self::block($content);
-
         self::$namespaced[$path] ??= [];
+
+        // If this path already has a definition, return the existing block
+        // This allows multiple routes to reference the same component
+        if (! empty(self::$namespaced[$path])) {
+            return self::$namespaced[$path][0];
+        }
+
+        $block = self::block($content);
         self::$namespaced[$path][] = $block;
 
         return $block;

--- a/tests/DuplicateInertiaComponents.test.ts
+++ b/tests/DuplicateInertiaComponents.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * These tests verify the deduplication behavior for Inertia components.
+ *
+ * When multiple controller methods render the same Inertia component,
+ * Wayfinder should generate only ONE TypeScript type definition for that component,
+ * while preserving references to all controller methods that use it.
+ *
+ * This prevents duplicate type definition errors in TypeScript.
+ */
+describe("Duplicate Inertia Components Deduplication", () => {
+    const typesPath = join(
+        __dirname,
+        "../workbench/resources/js/wayfinder/types.d.ts",
+    );
+    const content = readFileSync(typesPath, "utf-8");
+
+    test("types.d.ts file is generated", () => {
+        expect(content).toBeDefined();
+        expect(content.length).toBeGreaterThan(0);
+    });
+
+    describe("Dashboard component (rendered by dashboard() and duplicate())", () => {
+        test("contains Inertia.Pages namespace", () => {
+            expect(content).toContain("export namespace Inertia");
+            expect(content).toContain("export namespace Pages");
+        });
+
+        test("generates only ONE type definition for Dashboard", () => {
+            // Match "export type Dashboard =" anywhere in the file
+            const dashboardTypeMatches = content.match(/export type Dashboard\s*=/g);
+
+            expect(dashboardTypeMatches).toBeTruthy();
+            expect(dashboardTypeMatches?.length).toBe(1);
+        });
+
+        test("Dashboard type has correct definition", () => {
+            // The Dashboard type should extend SharedData with stats and recentActivity
+            expect(content).toMatch(/export type Dashboard\s*=\s*Inertia\.SharedData\s*&/);
+        });
+    });
+
+    describe("Settings/General component (rendered by settings() and duplicateWithData())", () => {
+        test("generates only ONE type definition for General", () => {
+            // Match "export type General =" in Settings namespace
+            const generalTypeMatches = content.match(/export type General\s*=/g);
+
+            expect(generalTypeMatches).toBeTruthy();
+            expect(generalTypeMatches?.length).toBe(1);
+        });
+
+        test("General type has correct definition with props", () => {
+            // The General type should extend SharedData and include user and preferences props
+            expect(content).toMatch(
+                /export type General\s*=\s*Inertia\.SharedData\s*&\s*\{[\s\S]*?user[\s\S]*?\}/
+            );
+        });
+
+        test("user prop has correct structure", () => {
+            // Extract the General type definition and check for user prop
+            const generalTypeMatch = content.match(
+                /export type General\s*=\s*Inertia\.SharedData\s*&\s*\{[^}]*user:[^}]*\}/
+            );
+
+            expect(generalTypeMatch).toBeTruthy();
+        });
+    });
+
+    describe("No duplicate type definitions in entire file", () => {
+        test("Dashboard type appears only once", () => {
+            const dashboardCount = (
+                content.match(/export type Dashboard\s*=/g) || []
+            ).length;
+
+            expect(dashboardCount).toBe(1);
+        });
+
+        test("General type appears only once", () => {
+            const generalCount = (
+                content.match(/export type General\s*=/g) || []
+            ).length;
+
+            expect(generalCount).toBe(1);
+        });
+
+        test("both controller methods are referenced in JSDoc", () => {
+            // The JSDoc should reference both InertiaController::settings and DuplicateInertiaController::duplicateWithData
+            const generalTypeSection = content.match(
+                /\/\*\*[\s\S]*?export type General\s*=/
+            );
+
+            expect(generalTypeSection).toBeTruthy();
+
+            const jsdocComment = generalTypeSection?.[0] || "";
+
+            // Both controllers should be referenced
+            expect(jsdocComment).toContain("InertiaController");
+            expect(jsdocComment).toContain("DuplicateInertiaController");
+        });
+    });
+});

--- a/workbench/app/Http/Controllers/DuplicateInertiaController.php
+++ b/workbench/app/Http/Controllers/DuplicateInertiaController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Controller to test deduplication of Inertia components.
+ *
+ * Multiple methods rendering the same component should only generate
+ * a single TypeScript type definition.
+ */
+class DuplicateInertiaController
+{
+    public function duplicate(): Response
+    {
+        return Inertia::render('Dashboard');
+    }
+
+    public function duplicateWithData(): Response
+    {
+        return Inertia::render('Settings/General', [
+            'user' => [
+                'name' => 'John Doe',
+                'email' => 'john@example.com',
+            ],
+        ]);
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AnonymousMiddlewareController;
 use App\Http\Controllers\ApiController;
 use App\Http\Controllers\DisallowedMethodNameController;
 use App\Http\Controllers\DomainController;
+use App\Http\Controllers\DuplicateInertiaController;
 use App\Http\Controllers\InertiaController;
 use App\Http\Controllers\InvokableController;
 use App\Http\Controllers\InvokablePlusController;
@@ -95,6 +96,9 @@ Route::get('/inertia/dashboard', [InertiaController::class, 'dashboard'])->name(
 Route::get('/inertia/settings', [InertiaController::class, 'settings'])->name('inertia.settings');
 Route::get('/inertia/profile', [InertiaController::class, 'profile'])->name('inertia.profile');
 Route::get('/inertia/unsafe', [InertiaController::class, 'unsafe'])->name('inertia.unsafe');
+
+Route::get('/inertia/duplicate', [DuplicateInertiaController::class, 'duplicate'])->name('inertia.duplicate');
+Route::get('/inertia/duplicate-with-data', [DuplicateInertiaController::class, 'duplicateWithData'])->name('inertia.duplicate.with-data');
 
 Route::get('/api/status', [ApiController::class, 'status'])->name('api.status');
 Route::get('/api/users', [ApiController::class, 'users'])->name('api.users');


### PR DESCRIPTION
## Context

Hey, submitting a PR where I noticed duplicate route registration pointing to the same Inertia component ended up producing duplicate Typescript definitions. 

**Problem Example:**

```php
// MarketingController.php
  public function home(): Response {
      return Inertia::render('Marketing/Home');
  }
  
  public function home_alternate(): Response {
      return Inertia::render('Marketing/Home');
  }
```

**Generated TypeScript:**

```typescript
    // ...
    export namespace Marketing {
        export type Home = Inertia.SharedData
        // ...
        export type Home = Inertia.SharedData // Would generate a TS error.
    }
    // ...
```


This adds a check to prevent adding duplicate definitions by preventing duplicate registration after the first.

---

Overall, I think this PR is sub-optimal, but it does output syntactically valid TS. However, this would end up breaking routes where the second has data being passed to it. Would be happy to discuss how you should name situations where this kind of example.

**Example:**

```php
// MarketingController.php
public function home(): Response {
    return Inertia::render('Marketing/Home');
}

public function home_alternate(): Response {
    return Inertia::render('Marketing/Home', [
        'user' => auth()->user()
    ]);
}
```

would miss out entirely on the typing of the second registration.

```typescript
export namespace Marketing {
    export type Home = Inertia.SharedData
}
```

If the namespace scheme is to stay the same, I would probably add some advice in docs for having separate controllers where the same Inertia component is used.