### PR TITLE
Fix relativePathFromFile path separator handling

### DIFF
--- a/src/Langs/TypeScript/Import.php
+++ b/src/Langs/TypeScript/Import.php
@@ -4,8 +4,6 @@ namespace Laravel\Wayfinder\Langs\TypeScript;
 
 use Laravel\Wayfinder\Langs\TypeScript;
 
-use function Illuminate\Filesystem\join_paths;
-
 class Import
 {
     protected bool $safe = false;
@@ -31,11 +29,12 @@ class Import
 
         $count = substr_count($path, DIRECTORY_SEPARATOR);
 
-        $final = '.' . '/' . ltrim(str_repeat('/..', $count), '/');
+        $final = '.'.'/'.ltrim(str_repeat('/..', $count), '/');
 
         if ($suffix) {
             $suffix = str_replace('\\', '/', $suffix);
-            return rtrim($final, '/') . '/' . ltrim($suffix, '/');
+
+            return rtrim($final, '/').'/'.ltrim($suffix, '/');
         }
 
         return $final;


### PR DESCRIPTION
Updated relativePathFromFile to consistently use forward slashes for path separators.

This fixes import declarations in Windows at least, of the resources that utilise `appendCommonImports`. I'm not sure if this would work on MacOS / Linux.

I believe this could fix https://github.com/laravel/wayfinder/issues/128

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
