### PR TITLE
Prevent null values from reaching quote() and causing a TypeError

### DIFF
--- a/src/Langs/TypeScript.php
+++ b/src/Langs/TypeScript.php
@@ -64,7 +64,11 @@ class TypeScript
             $values = collect($values);
         }
 
-        return self::type($type, $values->map(fn ($v) => self::quote($v))->implode(' | '));
+        return self::type($type, $values
+            ->filter(fn ($v) => ! is_null($v) && $v !== '')
+            ->map(fn ($v) => self::quote($v))
+            ->implode(' | ')
+        );
     }
 
     public static function backtick(string $content): string

--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -34,7 +34,10 @@ class Rules
     protected function resolveBaseType(): string
     {
         if ($inRule = $this->getRule('In')) {
-            return collect($inRule->getParams())->map(TypeScript::quote(...))->implode(' | ');
+            return collect($inRule->getParams())
+                ->filter(fn ($v) => ! is_null($v) && $v !== '')
+                ->map(TypeScript::quote(...))
+                ->implode(' | ');
         }
 
         if ($this->getRule('String')) {


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR hardens TypeScript generation by filtering out null and empty string values before invoking quote() on literal-union members. This prevents the following TypeError:

```
TypeError: TypeScript::quote(): Argument #1 ($string) must be of type string, null given
```

This is achieved by converting the arrays in ``TypeScript::literalUnion()`` to a Collection then apply the filter to strip if is_null or an empty string. The same filter is then applied in ``Validation\Rules::resolveBaseType()``.

There is an associated PR for Surveyor: https://github.com/laravel/surveyor/pull/20