### PR TITLE
Fix Inertia data converter producing invalid TypeScript on Windows

### DIFF
--- a/src/Converters/InertiaData.php
+++ b/src/Converters/InertiaData.php
@@ -12,16 +12,14 @@ class InertiaData extends Converter
     public function convert(InertiaResponse $response, Route $route): ?string
     {
         $fqn = str($response->component)
-            ->explode(DIRECTORY_SEPARATOR)
+            ->explode('/')
             ->map(fn ($part) => Str::studly($part))
             ->prepend('Inertia.Pages')
             ->join('.');
         $name = str($response->component)
-            ->afterLast(DIRECTORY_SEPARATOR)
+            ->afterLast('/')
             ->afterLast('.')
-            ->explode(DIRECTORY_SEPARATOR)
-            ->map(fn ($part) => Str::studly($part))
-            ->join(DIRECTORY_SEPARATOR);
+            ->studly();
         $type = $this->getType($response);
 
         TypeScript::addFqnToNamespaced($fqn, TypeScript::type($name, $type)->export())


### PR DESCRIPTION
Wayfinder will generate invalid TypeScript syntax when used on Windows due to `DIRECTORY_SEPARATOR` returning `\` but Inertia components using `/`. As far as I can tell, backslashes don't actually work in Inertia components.

Example:

```
resources/js/wayfinder/types.d.ts:27:70 - error TS1005: ';' expected.

27                         export type Response = Inertia.Pages.Settings/profile
                                                                        ~

resources/js/wayfinder/types.d.ts:55:70 - error TS1005: ';' expected.

55                         export type Response = Inertia.Pages.Settings/password
                                                                        ~

resources/js/wayfinder/types.d.ts:76:70 - error TS1005: ';' expected.

76                         export type Response = Inertia.Pages.Settings/twoFactor
                                                                        ~
```

After the fix:

```php
export type Response = Inertia.Pages.Settings.Profile
export type Response = Inertia.Pages.Settings.Password
export type Response = Inertia.Pages.Settings.TwoFactor
```

I also simplified the `$name` generation because calling `explode('/')` after the `afterLast('/')` always gives a 1 element array, making the whole explode/map/join chain redundant.