### PR TITLE
fix: eagerly render blade views to prevent crash

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -194,7 +194,7 @@ class GenerateCommand extends Command
                 'verbs' => $r->verbs(),
                 'uri' => $r->uri(),
             ]),
-        ]));
+        ])->render());
     }
 
     private function writeControllerMethodExport(Route $route, string $path): void
@@ -211,7 +211,7 @@ class GenerateCommand extends Command
             'verbs' => $route->verbs(),
             'uri' => $route->uri(),
             'withForm' => $this->option('with-form') ?? false,
-        ]));
+        ])->render());
     }
 
     private function writeNamedFile(Collection $routes, string $namespace): void
@@ -267,7 +267,7 @@ class GenerateCommand extends Command
             'verbs' => $route->verbs(),
             'uri' => $route->uri(),
             'withForm' => $this->option('with-form') ?? false,
-        ]));
+        ])->render());
     }
 
     private function writeBarrelFiles(array|Collection $children, string $parent): void


### PR DESCRIPTION
`writeControllerMethodExport`, `writeMultiRouteControllerMethodExport`, and `writeNamedMethodExport` store raw `View` objects in `$this->content` instead of rendered strings. When `writeBarrelFiles` later converts them to strings to check for duplicate constants, it triggers deferred Blade compilation inside a loop, which causes a crash on applications with many nested routes.

Fix: call `->render()` on the three `$this->view->make(...)` calls so content is resolved upfront.
