### PR TITLE
Respect `APP_URL` base path and port in generated URLs

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -14,6 +14,8 @@ use ReflectionClass;
 
 class Route
 {
+    private ?array $parsedRoot = null;
+
     public function __construct(
         private BaseRoute $base,
         private Collection $paramDefaults,
@@ -107,11 +109,7 @@ class Route
             ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
             ->toString();
 
-        if (
-            $uri !== '/'
-            && ! str_ends_with($uri, '://')
-            && ! str_ends_with($uri, '//')
-        ) {
+        if ($uri !== '/') {
             $uri = rtrim($uri, '/');
         }
 
@@ -129,7 +127,7 @@ class Route
         }
 
         if ($this->forcedRoot) {
-            $parts = $this->parseRootUrl($this->forcedRoot);
+            $parts = $this->getParsedRoot();
 
             if (isset($parts['scheme'])) {
                 return $parts['scheme'].'://';
@@ -142,26 +140,17 @@ class Route
     public function domain(): ?string
     {
         if ($this->base->getDomain()) {
-            $domain = $this->base->getDomain();
-            $port = $this->rootPort();
-
-            if ($port && ! str($domain)->contains(':')) {
-                return "{$domain}:{$port}";
-            }
-
-            return $domain;
+            return $this->base->getDomain();
         }
 
         if ($this->forcedRoot) {
-            $parts = $this->parseRootUrl($this->forcedRoot);
+            $parts = $this->getParsedRoot();
 
-            if (! isset($parts['host'])) {
-                return null;
+            if (isset($parts['host'])) {
+                $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+
+                return $parts['host'].$port;
             }
-
-            $port = isset($parts['port']) ? ':'.$parts['port'] : '';
-
-            return $parts['host'].$port;
         }
 
         return null;
@@ -231,7 +220,7 @@ class Route
 
     private function basePath(): string
     {
-        $parts = $this->parseRootUrl($this->forcedRoot ?: config('app.url'));
+        $parts = $this->getParsedRoot();
 
         if (! isset($parts['path'])) {
             return '';
@@ -242,24 +231,23 @@ class Route
         return $path === '/' ? '' : $path;
     }
 
-    private function rootPort(): ?int
+    private function getParsedRoot(): array
     {
-        $parts = $this->parseRootUrl($this->forcedRoot ?: config('app.url'));
+        if ($this->parsedRoot !== null) {
+            return $this->parsedRoot;
+        }
 
-        return isset($parts['port']) ? (int) $parts['port'] : null;
-    }
+        $url = $this->forcedRoot ?: config('app.url');
 
-    private function parseRootUrl(?string $url): array
-    {
         if (! is_string($url) || $url === '') {
-            return [];
+            return $this->parsedRoot = [];
         }
 
         if (str_starts_with($url, '//')) {
             $url = 'http:'.$url;
         }
 
-        return parse_url($url) ?: [];
+        return $this->parsedRoot = parse_url($url) ?: [];
     }
 
     private function relativePath(string $path)

--- a/src/Route.php
+++ b/src/Route.php
@@ -93,13 +93,27 @@ class Route
     {
         $defaultParams = $this->paramDefaults->mapWithKeys(fn ($value, $key) => ["{{$key}}" => "{{$key}?}"]);
 
-        $scheme = $this->scheme() ?? '//';
+        $uri = str($this->base->uri)->start('/')->toString();
 
-        $uri = str($this->base->uri)
-            ->start('/')
-            ->when($this->domain() !== null, fn ($uri) => $uri->prepend("{$scheme}{$this->domain()}"))
+        if (($basePath = $this->basePath()) !== '') {
+            $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
+        }
+
+        if (($domain = $this->domain()) !== null) {
+            $uri = ($this->scheme() ?? '//').$domain.$uri;
+        }
+
+        $uri = str($uri)
             ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
             ->toString();
+
+        if (
+            $uri !== '/'
+            && ! str_ends_with($uri, '://')
+            && ! str_ends_with($uri, '//')
+        ) {
+            $uri = rtrim($uri, '/');
+        }
 
         return Js::from($uri, JSON_UNESCAPED_SLASHES)->toHtml();
     }
@@ -114,17 +128,40 @@ class Route
             return 'https://';
         }
 
+        if ($this->forcedRoot) {
+            $parts = $this->parseRootUrl($this->forcedRoot);
+
+            if (isset($parts['scheme'])) {
+                return $parts['scheme'].'://';
+            }
+        }
+
         return $this->forcedScheme;
     }
 
     public function domain(): ?string
     {
         if ($this->base->getDomain()) {
-            return $this->base->getDomain();
+            $domain = $this->base->getDomain();
+            $port = $this->rootPort();
+
+            if ($port && ! str($domain)->contains(':')) {
+                return "{$domain}:{$port}";
+            }
+
+            return $domain;
         }
 
         if ($this->forcedRoot) {
-            return str_replace(['http://', 'https://'], '', $this->forcedRoot);
+            $parts = $this->parseRootUrl($this->forcedRoot);
+
+            if (! isset($parts['host'])) {
+                return null;
+            }
+
+            $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+
+            return $parts['host'].$port;
         }
 
         return null;
@@ -190,6 +227,39 @@ class Route
     private function finalJsMethod(string $method): string
     {
         return TypeScript::safeMethod($method, 'Method');
+    }
+
+    private function basePath(): string
+    {
+        $parts = $this->parseRootUrl($this->forcedRoot ?: config('app.url'));
+
+        if (! isset($parts['path'])) {
+            return '';
+        }
+
+        $path = '/'.trim($parts['path'], '/');
+
+        return $path === '/' ? '' : $path;
+    }
+
+    private function rootPort(): ?int
+    {
+        $parts = $this->parseRootUrl($this->forcedRoot ?: config('app.url'));
+
+        return isset($parts['port']) ? (int) $parts['port'] : null;
+    }
+
+    private function parseRootUrl(?string $url): array
+    {
+        if (! is_string($url) || $url === '') {
+            return [];
+        }
+
+        if (str_starts_with($url, '//')) {
+            $url = 'http:'.$url;
+        }
+
+        return parse_url($url) ?: [];
     }
 
     private function relativePath(string $path)

--- a/tests/AppUrlRootResolution.test.ts
+++ b/tests/AppUrlRootResolution.test.ts
@@ -34,7 +34,7 @@ test("prefixes generated URLs with APP_URL path", () => {
     expect(contents).toContain("url: '/v2/posts/{post}'");
 });
 
-test("appends APP_URL port to explicit domain routes without a port", () => {
+test("does not inject APP_URL port into explicit domain routes", () => {
     const outputPath = "/tmp/wayfinder-app-url-port";
 
     generateWithAppUrl("https://localhost:8001", outputPath);
@@ -47,8 +47,8 @@ test("appends APP_URL port to explicit domain routes without a port", () => {
         "utf8",
     );
 
-    expect(contents).toContain("url: '//example.test:8001/fixed-domain/{param}'");
+    expect(contents).toContain("url: '//example.test/fixed-domain/{param}'");
     expect(contents).toContain(
-        "url: '//{defaultDomain?}.au:8001/default-parameters-domain/{param}'",
+        "url: '//{defaultDomain?}.au/default-parameters-domain/{param}'",
     );
 });

--- a/tests/AppUrlRootResolution.test.ts
+++ b/tests/AppUrlRootResolution.test.ts
@@ -1,0 +1,54 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+const testbench = path.join(__dirname, "../vendor/bin/testbench");
+
+const generateWithAppUrl = (appUrl: string, outputPath: string) => {
+    rmSync(outputPath, { recursive: true, force: true });
+
+    execFileSync(
+        testbench,
+        ["wayfinder:generate", `--path=${outputPath}`, "--with-form"],
+        {
+            env: {
+                ...process.env,
+                APP_URL: appUrl,
+            },
+        },
+    );
+};
+
+test("prefixes generated URLs with APP_URL path", () => {
+    const outputPath = "/tmp/wayfinder-app-url-path";
+
+    generateWithAppUrl("http://localhost:8081/v2", outputPath);
+
+    const contents = readFileSync(
+        path.join(outputPath, "actions/App/Http/Controllers/PostController.ts"),
+        "utf8",
+    );
+
+    expect(contents).toContain("url: '/v2/posts'");
+    expect(contents).toContain("url: '/v2/posts/{post}'");
+});
+
+test("appends APP_URL port to explicit domain routes without a port", () => {
+    const outputPath = "/tmp/wayfinder-app-url-port";
+
+    generateWithAppUrl("https://localhost:8001", outputPath);
+
+    const contents = readFileSync(
+        path.join(
+            outputPath,
+            "actions/App/Http/Controllers/DomainController.ts",
+        ),
+        "utf8",
+    );
+
+    expect(contents).toContain("url: '//example.test:8001/fixed-domain/{param}'");
+    expect(contents).toContain(
+        "url: '//{defaultDomain?}.au:8001/default-parameters-domain/{param}'",
+    );
+});


### PR DESCRIPTION
## Summary
This improves URL generation when applications are hosted with a base path or custom port in `APP_URL`.

### What changed
- Prefix generated route URLs with the path portion of `APP_URL` (for example `/v2`).
- Append `APP_URL`'s port to explicit domain routes when the route domain does not already specify a port.
- Parse forced root URLs safely so host/path/port are handled separately.
- Added regression tests that run generation with custom `APP_URL` values.

## Real-world scenarios
### 1) Laravel installed in a subdirectory
If your app is deployed at `https://example.com/v2`, generated URLs should be `/v2/...`.

### 2) Multi-domain app on a custom port in local/dev
If routes use `Route::domain('backend.my-app.test')` and your app runs on `:8001`, generated links/forms should keep `:8001`.

## Before
```ts
// APP_URL=http://localhost:8081/v2
index.url()
// "/posts"

// APP_URL=https://localhost:8001
fixedDomain.definition.url
// "//example.test/fixed-domain/{param}"
```

## After
```ts
// APP_URL=http://localhost:8081/v2
index.url()
// "/v2/posts"

// APP_URL=https://localhost:8001
fixedDomain.definition.url
// "//example.test:8001/fixed-domain/{param}"
```

## Testing
```bash
npm test
```
