### PR TITLE
Keep multi-route action exports callable by default

### DIFF
--- a/resources/multi-method.blade.ts
+++ b/resources/multi-method.blade.ts
@@ -7,8 +7,8 @@
     ])
 @endforeach
 
-{!! when($shouldExport, 'export ') !!}const {!! $method !!} = {
+{!! when($shouldExport, 'export ') !!}const {!! $method !!} = Object.assign({!! $routes->first()['tempMethod'] !!}, {
 @foreach ($routes as $route)
     {!! $route['uri'] !!}: {!! $route['tempMethod'] !!},
 @endforeach
-}{{PHP_EOL}}
+}){{PHP_EOL}}

--- a/tests/TwoRoutesSameAction.test.ts
+++ b/tests/TwoRoutesSameAction.test.ts
@@ -1,5 +1,8 @@
 import { expect, it } from "vitest";
-import { same } from "../workbench/resources/js/actions/App/Http/Controllers/TwoRoutesSameActionController";
+import {
+    same,
+    submit,
+} from "../workbench/resources/js/actions/App/Http/Controllers/TwoRoutesSameActionController";
 
 it("creates a keyed dictionary of routes for multiple routes pointing to the same action", () => {
     expect(same["/two-routes-one-action-1"].url()).toBe(
@@ -16,5 +19,23 @@ it("creates a keyed dictionary of routes for multiple routes pointing to the sam
     expect(same["/two-routes-one-action-2"]()).toEqual({
         url: "/two-routes-one-action-2",
         method: "get",
+    });
+});
+
+it("keeps the default callable route API for multi-route actions", () => {
+    expect(same.url()).toBe("/two-routes-one-action-1");
+    expect(same()).toEqual({
+        url: "/two-routes-one-action-1",
+        method: "get",
+    });
+
+    expect(submit.url()).toBe("/two-routes-one-submit-1");
+    expect(submit()).toEqual({
+        url: "/two-routes-one-submit-1",
+        method: "post",
+    });
+    expect(submit.form()).toEqual({
+        action: "/two-routes-one-submit-1",
+        method: "post",
     });
 });

--- a/workbench/app/Http/Controllers/TwoRoutesSameActionController.php
+++ b/workbench/app/Http/Controllers/TwoRoutesSameActionController.php
@@ -8,4 +8,9 @@ class TwoRoutesSameActionController
     {
         //
     }
+
+    public function submit()
+    {
+        //
+    }
 }

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -76,6 +76,8 @@ Route::get('/prism/chat', [PrismChatController::class, 'index']);
 
 Route::get('/two-routes-one-action-1', [TwoRoutesSameActionController::class, 'same']);
 Route::get('/two-routes-one-action-2', [TwoRoutesSameActionController::class, 'same']);
+Route::post('/two-routes-one-submit-1', [TwoRoutesSameActionController::class, 'submit']);
+Route::post('/two-routes-one-submit-2', [TwoRoutesSameActionController::class, 'submit']);
 
 Route::get('/disallowed/delete', [DisallowedMethodNameController::class, 'delete']);
 Route::get('/disallowed/404', [DisallowedMethodNameController::class, '404'])->name('disallowed.404');


### PR DESCRIPTION
## Summary
This keeps action exports callable when multiple routes point to the same controller method.

### What changed
- Multi-route action exports now use `Object.assign(defaultRouteMethod, { ...routeMap })`.
- This preserves the existing URI-keyed map access while restoring the default callable API (`action()`, `action.url()`, `action.form()`).
- Added regression coverage for both `GET` and `POST` duplicate-action routes.

## Real-world scenario
If the same controller method is registered in multiple route files (for example `web.php` and `api.php`), generated actions currently become only a dictionary, so code like this breaks:

```ts
RegisteredUserController.store.form()
// TypeError: ...store.form is not a function
```

After this change, both styles work:

```ts
// default callable route (first registered)
RegisteredUserController.store.form()

// explicit route selection
RegisteredUserController.store['/api/register'].form()
```

## Testing
```bash
npm test
```
