### PR TITLE
fix: quote object keys that are not valid JS identifiers

### DIFF
--- a/src/TypeScript.php
+++ b/src/TypeScript.php
@@ -82,7 +82,7 @@ class TypeScript
             return $name;
         }
 
-        if (is_numeric($name[0])) {
+        if (! preg_match('/^[a-zA-Z_$][\w$]*$/', $name)) {
             return '"'.$name.'"';
         }
 

--- a/tests/DashedRouteName.test.ts
+++ b/tests/DashedRouteName.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "vitest";
+import { myDashedRoute } from "../workbench/resources/js/routes";
+
+it("handles dashed route names", () => {
+    expect(myDashedRoute.url()).toBe("/dashed-route");
+    expect(myDashedRoute()).toEqual({
+        url: "/dashed-route",
+        method: "get",
+    });
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -88,6 +88,10 @@ Route::get('/package-route', function () {
     //
 })->name('my-package::store');
 
+Route::get('/dashed-route', function () {
+    return 'Dashed';
+})->name('my-dashed-route');
+
 Route::prefix('/api/v1')->name('api.v1.')->group(function () {
     Route::get('/tasks', fn () => 'ok')->name('tasks');
 


### PR DESCRIPTION
## Summary

Fixes `TypeScript::quoteIfNeeded()` to properly detect and quote all non-valid JavaScript identifier keys, not just those starting with digits. Route names containing dashes, dots, or other special characters produced invalid TypeScript output.

Fixes laravel/wayfinder#161

## Problem

The previous check (`is_numeric($name[0])`) only caught names starting with digits. Route names like `my-route` or `api.users` were emitted as unquoted object keys, producing invalid TypeScript:

```typescript
// Before (invalid TS):
export const routes = {
    my-route: myRoute,   // SyntaxError: unexpected token '-'
    api.users: apiUsers,  // SyntaxError: unexpected token '.'
};
```

## Solution

Replace the `is_numeric($name[0])` check with a regex match against the JavaScript identifier pattern `^[a-zA-Z_$][\w$]*$`. Any name that does not match is wrapped in quotes.

```typescript
// After (valid TS):
export const routes = {
    "my-route": myRoute,
    "api.users": apiUsers,
};
```

## Test Plan

- Existing `DisallowedMethodNames` test exercises `quoteIfNeeded` for numeric-prefixed names
- Verify route names with dashes, dots, and other special characters are properly quoted
- Existing test suite passes with no regressions