### PR TITLE
Preserve functional URL defaults when adding runtime defaults

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -116,10 +116,12 @@ export const addUrlDefault = (
     key: string,
     value: string | number | boolean,
 ) => {
-    const params = urlDefaults();
-    params[key] = value;
+    const previousDefaults = urlDefaults;
 
-    urlDefaults = () => params;
+    urlDefaults = () => ({
+        ...previousDefaults(),
+        [key]: value,
+    });
 };
 
 export const applyUrlDefaults = <T extends UrlDefaults | undefined>(

--- a/tests/DefaultParameters.test.ts
+++ b/tests/DefaultParameters.test.ts
@@ -3,7 +3,11 @@ import {
     defaultParametersDomain,
     fixedDomain,
 } from "../workbench/resources/js/actions/App/Http/Controllers/DomainController";
-import { setUrlDefaults } from "../workbench/resources/js/wayfinder";
+import {
+    addUrlDefault,
+    applyUrlDefaults,
+    setUrlDefaults,
+} from "../workbench/resources/js/wayfinder";
 
 test("it can generate urls without default parameters set", () => {
     expect(fixedDomain.url({ param: "foo" })).toBe(
@@ -44,6 +48,31 @@ test("it can generate urls with dynamic function-based default URL parameters", 
             param: "bar",
         }),
     ).toBe("//dynamic-2.test.au/default-parameters-domain/bar");
+
+    expect(callCount).toBe(2);
+});
+
+test("it preserves dynamic URL defaults when adding runtime defaults", () => {
+    let callCount = 0;
+
+    setUrlDefaults(() => {
+        callCount++;
+        return {
+            defaultDomain: `dynamic-${callCount}.test`,
+        };
+    });
+
+    addUrlDefault("locale", "en");
+
+    expect(applyUrlDefaults(undefined)).toEqual({
+        defaultDomain: "dynamic-1.test",
+        locale: "en",
+    });
+
+    expect(applyUrlDefaults(undefined)).toEqual({
+        defaultDomain: "dynamic-2.test",
+        locale: "en",
+    });
 
     expect(callCount).toBe(2);
 });


### PR DESCRIPTION
## Summary
This preserves function-based URL defaults when `addUrlDefault()` is used.

Previously, if defaults were registered like this:

```ts
setUrlDefaults(() => ({
    tenant: page.props.tenant.slug,
}))
```

and then a runtime default was added with:

```ts
addUrlDefault("locale", "en")
```

the existing supplier would be evaluated once and replaced with a static object. That meant dynamic defaults stopped updating after the first call.

## What changed
- `addUrlDefault()` now composes with the existing defaults supplier instead of mutating a materialized object
- added regression coverage proving dynamic defaults remain dynamic after adding a runtime default

## Testing
```bash
npm test
```