### PR TITLE
Replace query parameter families when merging query params

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -60,6 +60,37 @@ const addNestedParams = (
     });
 };
 
+const clearParamFamily = (params: URLSearchParams, key: string) => {
+    params.delete(key);
+    params.delete(`${key}[]`);
+
+    const nestedKeys: string[] = [];
+
+    params.forEach((_, paramKey) => {
+        if (paramKey.startsWith(`${key}[`)) {
+            nestedKeys.push(paramKey);
+        }
+    });
+
+    nestedKeys.forEach((paramKey) => {
+        params.delete(paramKey);
+    });
+};
+
+const hasNestedParamFamily = (params: URLSearchParams, key: string) => {
+    if (params.has(`${key}[]`)) {
+        return true;
+    }
+
+    for (const paramKey of params.keys()) {
+        if (paramKey.startsWith(`${key}[`)) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
 export const queryParams = (options?: RouteQueryOptions) => {
     if (!options || (!options.query && !options.mergeQuery)) {
         return "";
@@ -78,27 +109,25 @@ export const queryParams = (options?: RouteQueryOptions) => {
         const queryValue = query[key];
 
         if (queryValue === undefined || queryValue === null) {
-            params.delete(key);
+            clearParamFamily(params, key);
             continue;
         }
 
         if (Array.isArray(queryValue)) {
-            if (params.has(`${key}[]`)) {
-                params.delete(`${key}[]`);
-            }
+            clearParamFamily(params, key);
 
             queryValue.forEach((value) => {
                 params.append(`${key}[]`, value.toString());
             });
         } else if (typeof queryValue === "object") {
-            params.forEach((_, paramKey) => {
-                if (paramKey.startsWith(`${key}[`)) {
-                    params.delete(paramKey);
-                }
-            });
+            clearParamFamily(params, key);
 
             addNestedParams(queryValue, key, params);
         } else {
+            if (hasNestedParamFamily(params, key)) {
+                clearParamFamily(params, key);
+            }
+
             params.set(key, getValue(queryValue));
         }
     }

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -78,10 +78,6 @@ const clearParamFamily = (params: URLSearchParams, key: string) => {
 };
 
 const hasNestedParamFamily = (params: URLSearchParams, key: string) => {
-    if (params.has(`${key}[]`)) {
-        return true;
-    }
-
     for (const paramKey of params.keys()) {
         if (paramKey.startsWith(`${key}[`)) {
             return true;

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -62,7 +62,6 @@ const addNestedParams = (
 
 const clearParamFamily = (params: URLSearchParams, key: string) => {
     params.delete(key);
-    params.delete(`${key}[]`);
 
     const nestedKeys: string[] = [];
 

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -90,22 +90,19 @@ export const queryParams = (options?: RouteQueryOptions) => {
         const queryValue = query[key];
 
         if (queryValue === undefined || queryValue === null) {
-            clearParamFamily(params, key);
+            if (includeExisting) clearParamFamily(params, key);
             continue;
         }
 
-        if (Array.isArray(queryValue)) {
-            clearParamFamily(params, key);
+        if (includeExisting) clearParamFamily(params, key);
 
+        if (Array.isArray(queryValue)) {
             queryValue.forEach((value) => {
                 params.append(`${key}[]`, value.toString());
             });
         } else if (typeof queryValue === "object") {
-            clearParamFamily(params, key);
-
             addNestedParams(queryValue, key, params);
         } else {
-            clearParamFamily(params, key);
             params.set(key, getValue(queryValue));
         }
     }

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -61,19 +61,15 @@ const addNestedParams = (
 };
 
 const clearParamFamily = (params: URLSearchParams, key: string) => {
-    params.delete(key);
-
-    const nestedKeys: string[] = [];
+    const toDelete = new Set<string>();
 
     params.forEach((_, paramKey) => {
-        if (paramKey.startsWith(`${key}[`)) {
-            nestedKeys.push(paramKey);
+        if (paramKey === key || paramKey.startsWith(`${key}[`)) {
+            toDelete.add(paramKey);
         }
     });
 
-    nestedKeys.forEach((paramKey) => {
-        params.delete(paramKey);
-    });
+    toDelete.forEach((paramKey) => params.delete(paramKey));
 };
 
 const hasNestedParamFamily = (params: URLSearchParams, key: string) => {

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -89,12 +89,13 @@ export const queryParams = (options?: RouteQueryOptions) => {
     for (const key in query) {
         const queryValue = query[key];
 
-        if (queryValue === undefined || queryValue === null) {
-            if (includeExisting) clearParamFamily(params, key);
-            continue;
+        if (includeExisting) {
+            clearParamFamily(params, key);
         }
 
-        if (includeExisting) clearParamFamily(params, key);
+        if (queryValue === undefined || queryValue === null) {
+            continue;
+        }
 
         if (Array.isArray(queryValue)) {
             queryValue.forEach((value) => {

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -72,16 +72,6 @@ const clearParamFamily = (params: URLSearchParams, key: string) => {
     toDelete.forEach((paramKey) => params.delete(paramKey));
 };
 
-const hasNestedParamFamily = (params: URLSearchParams, key: string) => {
-    for (const paramKey of params.keys()) {
-        if (paramKey.startsWith(`${key}[`)) {
-            return true;
-        }
-    }
-
-    return false;
-};
-
 export const queryParams = (options?: RouteQueryOptions) => {
     if (!options || (!options.query && !options.mergeQuery)) {
         return "";
@@ -115,10 +105,7 @@ export const queryParams = (options?: RouteQueryOptions) => {
 
             addNestedParams(queryValue, key, params);
         } else {
-            if (hasNestedParamFamily(params, key)) {
-                clearParamFamily(params, key);
-            }
-
+            clearParamFamily(params, key);
             params.set(key, getValue(queryValue));
         }
     }

--- a/tests/QueryParams.test.ts
+++ b/tests/QueryParams.test.ts
@@ -157,6 +157,81 @@ it("can delete existing params via undefined", () => {
     });
 });
 
+it("replaces an existing scalar param when merging an array param", () => {
+    window.location.search = "?foo=bar&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: ["qux", "baz"],
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active&foo%5B%5D=qux&foo%5B%5D=baz",
+        method: "get",
+    });
+});
+
+it("replaces an existing scalar param when merging an object param", () => {
+    window.location.search = "?foo=bar&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: { role: "admin" },
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active&foo%5Brole%5D=admin",
+        method: "get",
+    });
+});
+
+it("replaces an existing array param when merging a scalar param", () => {
+    window.location.search = "?foo[]=bar&foo[]=baz&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: "qux",
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active&foo=qux",
+        method: "get",
+    });
+});
+
+it("can delete existing array params via null", () => {
+    window.location.search = "?foo[]=bar&foo[]=baz&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: null,
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active",
+        method: "get",
+    });
+});
+
+it("can delete existing nested params via null", () => {
+    window.location.search = "?foo[role]=admin&foo[team]=ops&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: null,
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active",
+        method: "get",
+    });
+});
+
 it("can merge with the form method", () => {
     window.location.search = "?foo=bar&bar=baz";
 
@@ -195,7 +270,7 @@ it("can pass nested query parameters", () => {
     });
 });
 
-it("ignores nested object values with unallowed types", () => {
+it("replaces existing scalar params when merging nested object values", () => {
     window.location.search = "?parent=og";
 
     const query = (): {
@@ -223,7 +298,7 @@ it("ignores nested object values with unallowed types", () => {
             },
         }),
     ).toEqual({
-        action: "/posts?parent=og&_method=HEAD&parent%5Bstring%5D=string&parent%5Bnumber%5D=5&parent%5Bboolean%5D=1",
+        action: "/posts?_method=HEAD&parent%5Bstring%5D=string&parent%5Bnumber%5D=5&parent%5Bboolean%5D=1",
         method: "get",
     });
 });

--- a/tests/QueryParams.test.ts
+++ b/tests/QueryParams.test.ts
@@ -232,6 +232,66 @@ it("can delete existing nested params via null", () => {
     });
 });
 
+it("replaces an existing array param when merging an object param", () => {
+    window.location.search = "?foo[]=bar&foo[]=baz&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: { role: "admin" },
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active&foo%5Brole%5D=admin",
+        method: "get",
+    });
+});
+
+it("replaces an existing object param when merging an array param", () => {
+    window.location.search = "?foo[role]=admin&foo[team]=ops&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: ["qux", "baz"],
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active&foo%5B%5D=qux&foo%5B%5D=baz",
+        method: "get",
+    });
+});
+
+it("does not clobber params that share a prefix with the merged key", () => {
+    window.location.search = "?foo=bar&foobar=keep&foo_baz=keep";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: null,
+            },
+        }),
+    ).toEqual({
+        url: "/posts?foobar=keep&foo_baz=keep",
+        method: "get",
+    });
+});
+
+it("clears deeply nested params when merging a scalar", () => {
+    window.location.search = "?foo[a][b]=x&foo[a][c]=y&status=active";
+
+    expect(
+        index({
+            mergeQuery: {
+                foo: "scalar",
+            },
+        }),
+    ).toEqual({
+        url: "/posts?status=active&foo=scalar",
+        method: "get",
+    });
+});
+
 it("can merge with the form method", () => {
     window.location.search = "?foo=bar&bar=baz";
 

--- a/tests/QueryParams.test.ts
+++ b/tests/QueryParams.test.ts
@@ -90,7 +90,7 @@ it("can integrate basic params with existing window params", () => {
             },
         }),
     ).toEqual({
-        url: "/posts?foo=bar&bar=no&also=yes",
+        url: "/posts?foo=bar&also=yes&bar=no",
         method: "get",
     });
 });
@@ -302,7 +302,7 @@ it("can merge with the form method", () => {
             },
         }),
     ).toEqual({
-        action: "/posts?foo=sure&bar=baz&_method=HEAD",
+        action: "/posts?bar=baz&_method=HEAD&foo=sure",
         method: "get",
     });
 });


### PR DESCRIPTION
## Summary
This makes `mergeQuery` replace the full query-parameter family for a key instead of only one representation.

Previously, if the current URL contained a scalar value like `foo=bar`, merging an array or object for `foo` would leave the old scalar behind. Likewise, deleting `foo` would not remove existing `foo[]` or `foo[bar]` entries.

## What changed
- added a helper to clear an entire query-parameter family for a given key
- `mergeQuery` now clears conflicting scalar, array, and nested-object variants before writing the new value
- added regression coverage for scalar-to-array, scalar-to-object, array-to-scalar, and deleting existing array / nested params

## Testing
```bash
npm test
```