### PR TITLE
Add --relative option to generate relative URLs for domain-scoped routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ php artisan wayfinder:generate --skip-actions
 php artisan wayfinder:generate --skip-routes
 ```
 
+If you prefer relative URLs (for example, `/posts/1`) even for domain-scoped routes, use the `--relative` option:
+
+```
+php artisan wayfinder:generate --relative
+```
+
 You can safely `.gitignore` the `wayfinder`, `actions`, and `routes` directories as they are completely re-generated on every build.
 
 ## Usage

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -18,7 +18,7 @@ use function Laravel\Prompts\info;
 
 class GenerateCommand extends Command
 {
-    protected $signature = 'wayfinder:generate {--path=} {--skip-actions} {--skip-routes} {--with-form}';
+    protected $signature = 'wayfinder:generate {--path=} {--skip-actions} {--skip-routes} {--with-form} {--relative}';
 
     private ?string $forcedScheme;
 
@@ -68,7 +68,13 @@ class GenerateCommand extends Command
                 return $this->urlDefaults[$middleware];
             })->flatMap(fn ($r) => $r);
 
-            return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot);
+            return new Route(
+                $route,
+                $globalUrlDefaults->merge($defaults),
+                $this->forcedScheme,
+                $this->forcedRoot,
+                (bool) $this->option('relative'),
+            );
         });
 
         if (! $this->option('skip-actions')) {

--- a/src/Route.php
+++ b/src/Route.php
@@ -20,7 +20,8 @@ class Route
         private BaseRoute $base,
         private Collection $paramDefaults,
         private ?string $forcedScheme,
-        private ?string $forcedRoot
+        private ?string $forcedRoot,
+        private bool $relative = false,
     ) {
         //
     }
@@ -101,7 +102,7 @@ class Route
             $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
         }
 
-        if (($domain = $this->domain()) !== null) {
+        if (! $this->relative && ($domain = $this->domain()) !== null) {
             $uri = ($this->scheme() ?? '//').$domain.$uri;
         }
 

--- a/tests/AppUrlRootResolution.test.ts
+++ b/tests/AppUrlRootResolution.test.ts
@@ -52,3 +52,30 @@ test("does not inject APP_URL port into explicit domain routes", () => {
         "url: '//{defaultDomain?}.au/default-parameters-domain/{param}'",
     );
 });
+
+test("can generate relative urls for explicit domain routes", () => {
+    const outputPath = "/tmp/wayfinder-relative-urls";
+
+    rmSync(outputPath, { recursive: true, force: true });
+
+    execFileSync(
+        testbench,
+        [
+            "wayfinder:generate",
+            `--path=${outputPath}`,
+            "--with-form",
+            "--relative",
+        ],
+    );
+
+    const contents = readFileSync(
+        path.join(
+            outputPath,
+            "actions/App/Http/Controllers/DomainController.ts",
+        ),
+        "utf8",
+    );
+
+    expect(contents).toContain("url: '/fixed-domain/{param}'");
+    expect(contents).toContain("url: '/default-parameters-domain/{param}'");
+});


### PR DESCRIPTION
# Add --relative option to generate relative URLs for domain-scoped routes

## Summary

This PR adds a new `--relative` option to `php artisan wayfinder:generate` so domain-scoped routes can be generated as relative paths instead of absolute or protocol-relative URLs.

Previously, routes with an explicit domain were always generated with a domain in the URL output. With this change, users can opt in to relative URLs such as `/fixed-domain/{param}` and `/default-parameters-domain/{param}` even when the route is domain-scoped.

## Target Branch

This PR targets `main`, which is currently supported according to Laravel's release support policy:
https://laravel.com/docs/releases#support-policy

Branch targeting follows Laravel's contribution guidance:
https://laravel.com/docs/contributions#which-branch

## End-User Benefit

- Enables frontend apps to keep URL generation environment-agnostic by using relative paths.
- Avoids leaking or coupling generated client code to domain/protocol decisions when that is not desired.
- Makes local, staging, and production usage simpler when host resolution is handled externally (for example, by browser origin, reverse proxies, or runtime configuration).

## Why This Is Safe / Non-Breaking

- The change is opt-in via `--relative`; default behavior is unchanged.
- Existing command usage without the new option continues to generate the same URLs as before.
- No existing options were removed or behavior changed implicitly.
- The Route generation change is narrowly scoped to skipping domain prefixing only when `--relative` is enabled.

## Implementation Details

- Added `--relative` to the command signature in `GenerateCommand`.
- Propagated the `relative` flag into `Route` construction.
- Updated `Route::uri()` to skip domain prefixing when `relative` is true.
- Documented the new option in the README generation section.

## Tests

Added coverage in `tests/AppUrlRootResolution.test.ts`:

1. `can generate relative urls for explicit domain routes`
2. Verifies generated action output contains `url: '/fixed-domain/{param}'`
3. Verifies generated action output contains `url: '/default-parameters-domain/{param}'`

This ensures domain-scoped routes can be emitted as relative URLs when `--relative` is passed.

## Upgrade Notes

No upgrade steps are required. This is a backward-compatible, additive feature.