### PR TITLE
Add tests covering inline variable assignment inside arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/routing": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
         "laravel/ranger": "^0.1.0",
-        "laravel/surveyor": "^0.1.0",
+        "laravel/surveyor": "^0.1.10",
         "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {

--- a/tests/InertiaData.test.ts
+++ b/tests/InertiaData.test.ts
@@ -30,4 +30,11 @@ describe("InertiaData", () => {
         );
         expect(existsSync(inertiaTypesPath)).toBe(true);
     });
+
+    test("inline-assigned props resolve to their underlying type", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain(
+            "export type InlineAssignment = Inertia.SharedData & { stats: {a: number, b: number }, first: number }"
+        );
+    });
 });

--- a/workbench/app/Http/Controllers/InertiaController.php
+++ b/workbench/app/Http/Controllers/InertiaController.php
@@ -65,4 +65,12 @@ class InertiaController
             'canLogin' => true,
         ]);
     }
+
+    public function inlineAssignment(): Response
+    {
+        return inertia('InlineAssignment', [
+            'stats' => $stats = ['a' => 1, 'b' => 2],
+            'first' => $stats['a'],
+        ]);
+    }
 }

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -107,6 +107,7 @@ Route::get('/inertia/settings', [InertiaController::class, 'settings'])->name('i
 Route::get('/inertia/profile', [InertiaController::class, 'profile'])->name('inertia.profile');
 Route::get('/inertia/unsafe', [InertiaController::class, 'unsafe'])->name('inertia.unsafe');
 Route::get('/inertia/conditional', [InertiaController::class, 'conditional'])->name('inertia.conditional');
+Route::get('/inertia/inline-assignment', [InertiaController::class, 'inlineAssignment'])->name('inertia.inline-assignment');
 
 Route::get('/inertia/modular/login', [ModularInertiaController::class, 'login'])->name('inertia.modular.login');
 Route::get('/inertia/modular/register', [ModularInertiaController::class, 'register'])->name('inertia.modular.register');


### PR DESCRIPTION
Adds test coverage for variable assignments inside arrays, e.g.:

```php
public function index(Request $request)
{
    return [
        'foo' => $foo = 'bar',
    ];
}
```

Requires Surveyor `^0.1.10`.

This isn't Inertia-specific, it applies to plain responses and probably any inline assignments in other places too, that was just the easiest path to add tests for.

See #160 and laravel/surveyor#30.

Tests failures aren't related to this PR, they fail on the base `next` branch too.