### PR TITLE
Generate types for Eloquent API Resources and JSON:API responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "illuminate/filesystem": "^11.0|^12.0|^13.0",
         "illuminate/routing": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
-        "laravel/ranger": "^0.1.0",
-        "laravel/surveyor": "^0.1.0",
+        "laravel/ranger": "^0.2.0",
+        "laravel/surveyor": "^0.2.1",
         "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {

--- a/src/Converters/JsonApiData.php
+++ b/src/Converters/JsonApiData.php
@@ -4,7 +4,6 @@ namespace Laravel\Wayfinder\Converters;
 
 use Laravel\Ranger\Components\JsonApiResponse;
 use Laravel\Ranger\Components\Route;
-use Laravel\Surveyor\Types\Contracts\Type;
 use Laravel\Wayfinder\Langs\TypeScript;
 
 class JsonApiData extends Converter
@@ -26,16 +25,8 @@ class JsonApiData extends Converter
         }
 
         if (! empty($response->relationships)) {
-            $relObj = TypeScript::typeObject();
-
-            foreach ($response->relationships as $name => $relType) {
-                $relObj->key($name)
-                    ->value('{ data: { id: string, type: string } | null }')
-                    ->optional();
-            }
-
             $resourceObject->key('relationships')
-                ->value((string) $relObj)
+                ->value((string) TypeScript::objectToTypeObject($response->relationships, false))
                 ->optional();
         }
 

--- a/src/Converters/JsonApiData.php
+++ b/src/Converters/JsonApiData.php
@@ -54,7 +54,7 @@ class JsonApiData extends Converter
         $dataType = (string) $resourceObject;
 
         if ($response->isCollection) {
-            return '{ data: Array<'.$dataType.'> }';
+            return '{ data: '.$dataType.'[] }';
         }
 
         return '{ data: '.$dataType.' }';

--- a/src/Converters/JsonApiData.php
+++ b/src/Converters/JsonApiData.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Wayfinder\Converters;
+
+use Laravel\Ranger\Components\JsonApiResponse;
+use Laravel\Ranger\Components\Route;
+use Laravel\Surveyor\Types\Contracts\Type;
+use Laravel\Wayfinder\Langs\TypeScript;
+
+class JsonApiData extends Converter
+{
+    public function convert(JsonApiResponse $response, Route $route): ?string
+    {
+        if (! $route->hasController()) {
+            return null;
+        }
+
+        $resourceObject = TypeScript::typeObject();
+        $resourceObject->key('id')->value('string');
+        $resourceObject->key('type')->value('string');
+
+        if (! empty($response->attributes)) {
+            $resourceObject->key('attributes')
+                ->value((string) TypeScript::objectToTypeObject($response->attributes, false))
+                ->optional();
+        }
+
+        if (! empty($response->relationships)) {
+            $relObj = TypeScript::typeObject();
+
+            foreach ($response->relationships as $name => $relType) {
+                $relObj->key($name)
+                    ->value('{ data: { id: string, type: string } | null }')
+                    ->optional();
+            }
+
+            $resourceObject->key('relationships')
+                ->value((string) $relObj)
+                ->optional();
+        }
+
+        if (! empty($response->links)) {
+            $resourceObject->key('links')
+                ->value((string) TypeScript::objectToTypeObject($response->links, false))
+                ->optional();
+        }
+
+        if (! empty($response->meta)) {
+            $resourceObject->key('meta')
+                ->value((string) TypeScript::objectToTypeObject($response->meta, false))
+                ->optional();
+        }
+
+        $dataType = (string) $resourceObject;
+
+        if ($response->isCollection) {
+            return '{ data: Array<'.$dataType.'> }';
+        }
+
+        return '{ data: '.$dataType.' }';
+    }
+}

--- a/src/Converters/ResourceData.php
+++ b/src/Converters/ResourceData.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Laravel\Wayfinder\Converters;
+
+use Laravel\Ranger\Components\ResourceResponse;
+use Laravel\Ranger\Components\Route;
+use Laravel\Surveyor\Types\Contracts\Type;
+use Laravel\Wayfinder\Langs\TypeScript;
+
+class ResourceData extends Converter
+{
+    public function convert(ResourceResponse $response, Route $route): ?string
+    {
+        if (! $route->hasController()) {
+            return null;
+        }
+
+        $dataType = (string) TypeScript::objectToTypeObject($response->data, false);
+
+        if ($response->isCollection) {
+            $dataType = "Array<{$dataType}>";
+        }
+
+        if ($response->wrap !== null) {
+            $outer = TypeScript::typeObject();
+            $outer->key($response->wrap)->value($dataType);
+
+            foreach ($response->additional as $key => $type) {
+                $value = $type instanceof Type ? TypeScript::fromSurveyorType($type) : (string) $type;
+                $outer->key($key)->value($value);
+            }
+
+            return (string) $outer;
+        }
+
+        // No wrapping — merge additional into data shape if present
+        if (! empty($response->additional)) {
+            $combined = array_merge($response->data, $response->additional);
+
+            return (string) TypeScript::objectToTypeObject($combined, false);
+        }
+
+        return $dataType;
+    }
+}

--- a/src/Converters/ResourceData.php
+++ b/src/Converters/ResourceData.php
@@ -18,7 +18,7 @@ class ResourceData extends Converter
         $dataType = (string) TypeScript::objectToTypeObject($response->data, false);
 
         if ($response->isCollection) {
-            $dataType = "Array<{$dataType}>";
+            $dataType = "{$dataType}[]";
         }
 
         if ($response->wrap !== null) {

--- a/src/Converters/Routes.php
+++ b/src/Converters/Routes.php
@@ -70,21 +70,13 @@ class Routes extends Converter
             $responseTypes = [];
 
             foreach ($route->possibleResponses() as $response) {
-                if ($response instanceof InertiaResponse) {
-                    $responseTypes[] = $this->inertiaDataConverter->convert($response, $route);
-                }
-
-                if ($response instanceof JsonResponse) {
-                    $responseTypes[] = $this->jsonDataConverter->convert($response, $route);
-                }
-
-                if ($response instanceof ResourceResponse) {
-                    $responseTypes[] = $this->resourceDataConverter->convert($response, $route);
-                }
-
-                if ($response instanceof JsonApiResponse) {
-                    $responseTypes[] = $this->jsonApiDataConverter->convert($response, $route);
-                }
+                $responseTypes[] = match (true) {
+                    $response instanceof InertiaResponse => $this->inertiaDataConverter->convert($response, $route),
+                    $response instanceof JsonResponse => $this->jsonDataConverter->convert($response, $route),
+                    $response instanceof ResourceResponse => $this->resourceDataConverter->convert($response, $route),
+                    $response instanceof JsonApiResponse => $this->jsonApiDataConverter->convert($response, $route),
+                    default => null,
+                };
             }
 
             $responseTypes = array_filter($responseTypes);

--- a/src/Converters/Routes.php
+++ b/src/Converters/Routes.php
@@ -5,6 +5,7 @@ namespace Laravel\Wayfinder\Converters;
 use Illuminate\Config\Repository;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\InertiaResponse;
+use Laravel\Ranger\Components\JsonApiResponse;
 use Laravel\Ranger\Components\JsonResponse;
 use Laravel\Ranger\Components\ResourceResponse;
 use Laravel\Ranger\Components\Route;
@@ -40,6 +41,7 @@ class Routes extends Converter
         protected InertiaData $inertiaDataConverter,
         protected JsonData $jsonDataConverter,
         protected ResourceData $resourceDataConverter,
+        protected JsonApiData $jsonApiDataConverter,
         protected FormRequests $formRequestConverter,
         protected Repository $config,
     ) {
@@ -78,6 +80,10 @@ class Routes extends Converter
 
                 if ($response instanceof ResourceResponse) {
                     $responseTypes[] = $this->resourceDataConverter->convert($response, $route);
+                }
+
+                if ($response instanceof JsonApiResponse) {
+                    $responseTypes[] = $this->jsonApiDataConverter->convert($response, $route);
                 }
             }
 

--- a/src/Converters/Routes.php
+++ b/src/Converters/Routes.php
@@ -6,6 +6,7 @@ use Illuminate\Config\Repository;
 use Illuminate\Support\Collection;
 use Laravel\Ranger\Components\InertiaResponse;
 use Laravel\Ranger\Components\JsonResponse;
+use Laravel\Ranger\Components\ResourceResponse;
 use Laravel\Ranger\Components\Route;
 use Laravel\Ranger\Support\RouteParameter;
 use Laravel\Ranger\Support\Verb;
@@ -38,6 +39,7 @@ class Routes extends Converter
     public function __construct(
         protected InertiaData $inertiaDataConverter,
         protected JsonData $jsonDataConverter,
+        protected ResourceData $resourceDataConverter,
         protected FormRequests $formRequestConverter,
         protected Repository $config,
     ) {
@@ -72,6 +74,10 @@ class Routes extends Converter
 
                 if ($response instanceof JsonResponse) {
                     $responseTypes[] = $this->jsonDataConverter->convert($response, $route);
+                }
+
+                if ($response instanceof ResourceResponse) {
+                    $responseTypes[] = $this->resourceDataConverter->convert($response, $route);
                 }
             }
 

--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -5,6 +5,7 @@ namespace Laravel\Wayfinder\Registry;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
+use Laravel\Surveyor\Analyzer\ArrayableResolver;
 use Laravel\Surveyor\Types;
 use Laravel\Surveyor\Types\Contracts\Type;
 use Laravel\Wayfinder\Langs\TypeScript;
@@ -91,8 +92,22 @@ class TypeScriptConverter extends AbstractConverter
         $matched = match ($value->toString()) {
             Stringable::class => 'string',
             Collection::class => 'unknown[]',
-            default => $value->replace('\\', '.')->toString(),
+            default => null,
         };
+
+        if ($matched === null) {
+            try {
+                $resolved = app(ArrayableResolver::class)->resolve($result);
+
+                if ($resolved) {
+                    return $this->convert($resolved);
+                }
+            } catch (\Throwable $e) {
+                // ArrayableResolver not available or resolution failed
+            }
+
+            $matched = $value->replace('\\', '.')->toString();
+        }
 
         return $this->decorate($matched, $result);
     }

--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -96,14 +96,10 @@ class TypeScriptConverter extends AbstractConverter
         };
 
         if ($matched === null) {
-            try {
-                $resolved = app(ArrayableResolver::class)->resolve($result);
+            $resolved = app(ArrayableResolver::class)->resolve($result);
 
-                if ($resolved) {
-                    return $this->convert($resolved);
-                }
-            } catch (\Throwable $e) {
-                // ArrayableResolver not available or resolution failed
+            if ($resolved) {
+                return $this->convert($resolved);
             }
 
             $matched = $value->replace('\\', '.')->toString();

--- a/tests/ResourceData.test.ts
+++ b/tests/ResourceData.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, test } from "vitest";
+
+describe("ResourceData", () => {
+    const typesPath = join(
+        __dirname,
+        "../workbench/resources/js/wayfinder/types.d.ts"
+    );
+
+    const types = () => readFileSync(typesPath, "utf-8");
+
+    test("types.d.ts contains ResourceTestController namespace", () => {
+        expect(types()).toContain("export namespace ResourceTestController");
+    });
+
+    test("single JsonResource emits a `data`-wrapped shape", () => {
+        expect(types()).toContain(
+            "{ data: { id: number, name: string, price: number, in_stock: true } } | Record<string, never>"
+        );
+    });
+
+    test("JsonResource collection emits an array under `data`", () => {
+        expect(types()).toContain(
+            "{ data: Array<{ id: number, name: string, price: number, in_stock: true }> } | Record<string, never>"
+        );
+    });
+
+    test("custom $wrap key is honored", () => {
+        expect(types()).toContain(
+            "{ product: { id: number, name: string } } | Record<string, never>"
+        );
+    });
+
+    test("JsonApiResource emits id/type/attributes/links/meta", () => {
+        expect(types()).toContain(
+            "{ data: { id: string, type: string, attributes?: { name: string, slug: string, created_at: string }, links?: { self: string }, meta?: { count: number } } }"
+        );
+    });
+
+    test("JsonApiResource collection wraps the resource shape in Array", () => {
+        expect(types()).toContain(
+            "{ data: Array<{ id: string, type: string, attributes?: { name: string, slug: string, created_at: string }, links?: { self: string }, meta?: { count: number } }> }"
+        );
+    });
+
+    test("Eloquent-bound resource resolves $this->property to model types", () => {
+        expect(types()).toContain(
+            "{ data: { id: number, name: string, email: string } } | Record<string, never>"
+        );
+    });
+
+    test("Eloquent-bound resource collection resolves model types", () => {
+        expect(types()).toContain(
+            "{ data: Array<{ id: number, name: string, email: string }> } | Record<string, never>"
+        );
+    });
+});

--- a/tests/ResourceData.test.ts
+++ b/tests/ResourceData.test.ts
@@ -22,7 +22,7 @@ describe("ResourceData", () => {
 
     test("JsonResource collection emits an array under `data`", () => {
         expect(types()).toContain(
-            "{ data: Array<{ id: number, name: string, price: number, in_stock: true }> } | Record<string, never>"
+            "{ data: { id: number, name: string, price: number, in_stock: true }[] } | Record<string, never>"
         );
     });
 
@@ -38,9 +38,9 @@ describe("ResourceData", () => {
         );
     });
 
-    test("JsonApiResource collection wraps the resource shape in Array", () => {
+    test("JsonApiResource collection wraps the resource shape in an array", () => {
         expect(types()).toContain(
-            "{ data: Array<{ id: string, type: string, attributes?: { name: string, slug: string, created_at: string }, links?: { self: string }, meta?: { count: number } }> }"
+            "{ data: { id: string, type: string, attributes?: { name: string, slug: string, created_at: string }, links?: { self: string }, meta?: { count: number } }[] }"
         );
     });
 
@@ -52,7 +52,7 @@ describe("ResourceData", () => {
 
     test("Eloquent-bound resource collection resolves model types", () => {
         expect(types()).toContain(
-            "{ data: Array<{ id: number, name: string, email: string }> } | Record<string, never>"
+            "{ data: { id: number, name: string, email: string }[] } | Record<string, never>"
         );
     });
 });

--- a/tests/ResourceData.test.ts
+++ b/tests/ResourceData.test.ts
@@ -16,19 +16,19 @@ describe("ResourceData", () => {
 
     test("single JsonResource emits a `data`-wrapped shape", () => {
         expect(types()).toContain(
-            "{ data: { id: number, name: string, price: number, in_stock: true } } | Record<string, never>"
+            "{ data: { id: number, name: string, price: number, in_stock: true } }"
         );
     });
 
     test("JsonResource collection emits an array under `data`", () => {
         expect(types()).toContain(
-            "{ data: { id: number, name: string, price: number, in_stock: true }[] } | Record<string, never>"
+            "{ data: { id: number, name: string, price: number, in_stock: true }[] }"
         );
     });
 
     test("custom $wrap key is honored", () => {
         expect(types()).toContain(
-            "{ product: { id: number, name: string } } | Record<string, never>"
+            "{ product: { id: number, name: string } }"
         );
     });
 
@@ -46,13 +46,13 @@ describe("ResourceData", () => {
 
     test("Eloquent-bound resource resolves $this->property to model types", () => {
         expect(types()).toContain(
-            "{ data: { id: number, name: string, email: string } } | Record<string, never>"
+            "{ data: { id: number, name: string, email: string } }"
         );
     });
 
     test("Eloquent-bound resource collection resolves model types", () => {
         expect(types()).toContain(
-            "{ data: { id: number, name: string, email: string }[] } | Record<string, never>"
+            "{ data: { id: number, name: string, email: string }[] }"
         );
     });
 });

--- a/tests/ResourceData.test.ts
+++ b/tests/ResourceData.test.ts
@@ -55,4 +55,11 @@ describe("ResourceData", () => {
             "{ data: { id: number, name: string, email: string }[] }"
         );
     });
+
+    test("JsonApiResource relationships emit cardinality-aware shapes", () => {
+        // to-one is { data: { id, type } | null }, to-many is { data: { id, type }[] }
+        expect(types()).toContain(
+            "relationships?: { featuredProduct: {data: {id: string, type: string } | null }, relatedProducts: {data: {id: string, type: string }[] } }"
+        );
+    });
 });

--- a/workbench/app/Http/Controllers/ResourceTestController.php
+++ b/workbench/app/Http/Controllers/ResourceTestController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\CategoryJsonApiResource;
 use App\Http\Resources\ProductResource;
+use App\Http\Resources\UserJsonApiResource;
 use App\Http\Resources\UserResource;
 use App\Http\Resources\WrappedProductResource;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -44,5 +45,10 @@ class ResourceTestController
     public function users(): JsonResource
     {
         return UserResource::collection([]);
+    }
+
+    public function userJsonApi(): JsonApiResource
+    {
+        return new UserJsonApiResource(null);
     }
 }

--- a/workbench/app/Http/Controllers/ResourceTestController.php
+++ b/workbench/app/Http/Controllers/ResourceTestController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\CategoryJsonApiResource;
+use App\Http\Resources\ProductResource;
+use App\Http\Resources\UserResource;
+use App\Http\Resources\WrappedProductResource;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+class ResourceTestController
+{
+    public function show(): JsonResource
+    {
+        return new ProductResource(null);
+    }
+
+    public function index(): JsonResource
+    {
+        return ProductResource::collection([]);
+    }
+
+    public function wrapped(): JsonResource
+    {
+        return new WrappedProductResource(null);
+    }
+
+    public function jsonApi(): JsonApiResource
+    {
+        return new CategoryJsonApiResource(null);
+    }
+
+    public function jsonApiCollection(): JsonApiResource
+    {
+        return CategoryJsonApiResource::collection([]);
+    }
+
+    public function user(): JsonResource
+    {
+        return new UserResource(null);
+    }
+
+    public function users(): JsonResource
+    {
+        return UserResource::collection([]);
+    }
+}

--- a/workbench/app/Http/Resources/CategoryJsonApiResource.php
+++ b/workbench/app/Http/Resources/CategoryJsonApiResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+class CategoryJsonApiResource extends JsonApiResource
+{
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => 'Tools',
+            'slug' => 'tools',
+            'created_at' => '2026-01-01',
+        ];
+    }
+
+    public function toLinks(Request $request): array
+    {
+        return [
+            'self' => '/categories/1',
+        ];
+    }
+
+    public function toMeta(Request $request): array
+    {
+        return [
+            'count' => 5,
+        ];
+    }
+}

--- a/workbench/app/Http/Resources/ProductResource.php
+++ b/workbench/app/Http/Resources/ProductResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ProductResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => 1,
+            'name' => 'Widget',
+            'price' => 9.99,
+            'in_stock' => true,
+        ];
+    }
+}

--- a/workbench/app/Http/Resources/UserJsonApiResource.php
+++ b/workbench/app/Http/Resources/UserJsonApiResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+
+/**
+ * @mixin \App\Models\User
+ */
+class UserJsonApiResource extends JsonApiResource
+{
+    public static $relationships = ['featuredProduct', 'relatedProducts'];
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => 'Joe',
+            'email' => 'joe@example.com',
+        ];
+    }
+}

--- a/workbench/app/Http/Resources/UserResource.php
+++ b/workbench/app/Http/Resources/UserResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\User
+ */
+class UserResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+    }
+}

--- a/workbench/app/Http/Resources/WrappedProductResource.php
+++ b/workbench/app/Http/Resources/WrappedProductResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WrappedProductResource extends JsonResource
+{
+    public static $wrap = 'product';
+
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => 1,
+            'name' => 'Widget',
+        ];
+    }
+}

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -18,6 +18,8 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $email_verified_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property Product $featuredProduct
+ * @property array<int, Product> $relatedProducts
  */
 class User extends Authenticatable
 {

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\AnonymousMiddlewareController;
 use App\Http\Controllers\ApiController;
+use App\Http\Controllers\ResourceTestController;
 use App\Http\Controllers\DisallowedMethodNameController;
 use App\Http\Controllers\DomainController;
 use App\Http\Controllers\DuplicateInertiaController;
@@ -109,6 +110,14 @@ Route::get('/inertia/duplicate-with-data', [DuplicateInertiaController::class, '
 
 Route::get('/api/status', [ApiController::class, 'status'])->name('api.status');
 Route::get('/api/users', [ApiController::class, 'users'])->name('api.users');
+
+Route::get('/products/{product}', [ResourceTestController::class, 'show'])->name('products.show');
+Route::get('/products', [ResourceTestController::class, 'index'])->name('products.index');
+Route::get('/products/wrapped', [ResourceTestController::class, 'wrapped'])->name('products.wrapped');
+Route::get('/categories/json-api/{category}', [ResourceTestController::class, 'jsonApi'])->name('categories.jsonApi');
+Route::get('/categories/json-api', [ResourceTestController::class, 'jsonApiCollection'])->name('categories.jsonApi.collection');
+Route::get('/users-resource/{user}', [ResourceTestController::class, 'user'])->name('users-resource.show');
+Route::get('/users-resource', [ResourceTestController::class, 'users'])->name('users-resource.index');
 
 Route::get('/prism', [PrismController::class, 'index'])->name('prism.index');
 Route::get('/prism/nested', [NestedPrismController::class, 'nested'])->name('prism.prism.nested');

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -118,6 +118,7 @@ Route::get('/categories/json-api/{category}', [ResourceTestController::class, 'j
 Route::get('/categories/json-api', [ResourceTestController::class, 'jsonApiCollection'])->name('categories.jsonApi.collection');
 Route::get('/users-resource/{user}', [ResourceTestController::class, 'user'])->name('users-resource.show');
 Route::get('/users-resource', [ResourceTestController::class, 'users'])->name('users-resource.index');
+Route::get('/users-json-api/{user}', [ResourceTestController::class, 'userJsonApi'])->name('users-json-api.show');
 
 Route::get('/prism', [PrismController::class, 'index'])->name('prism.index');
 Route::get('/prism/nested', [NestedPrismController::class, 'nested'])->name('prism.prism.nested');


### PR DESCRIPTION
Wayfinder now picks up controllers returning `JsonResource`, `ResourceCollection`, or `JsonApiResource` and emits a matching `Response` type. Eloquent-bound resources resolve `$this->property` against the model's `@property` PHPDoc, so a `UserResource` returning `$this->id, $this->name` produces `{ data: { id: number, name: string } }`. Custom `$wrap` keys are honored, and JSON:API expands into `{ data: { id, type, attributes?, links?, meta? } }`.

Bumps `laravel/ranger` to ^0.2.0 and `laravel/surveyor` to ^0.2.1 for the new `ResourceResponse` / `JsonApiResponse` components and the `ArrayableResolver` used to unwrap arbitrary `Arrayable` classes returned from a route.