### PR TITLE
Type narrow Eloquent Collection item types

### DIFF
--- a/src/Langs/TypeScript/Converters/RouteMethod.php
+++ b/src/Langs/TypeScript/Converters/RouteMethod.php
@@ -141,7 +141,22 @@ class RouteMethod
             }
         }
 
-        $block->annotation('route', '"'.$this->route->uri().'"');
+        $block->annotation('route', '"'.$this->resolvedUrl().'"');
+    }
+
+    protected function resolvedUrl(): string
+    {
+        $uri = $this->route->uri();
+
+        if ($domain = $this->route->domain()) {
+            $scheme = $this->route->scheme() ?? '//';
+            foreach ($this->route->parameters() as $parameter) {
+                $domain = str_replace("{{$parameter->name}}", $parameter->placeholder, $domain);
+            }
+            $uri = $scheme.$domain.$uri;
+        }
+
+        return $uri;
     }
 
     protected function collectArgTypes(): array
@@ -186,7 +201,7 @@ class RouteMethod
 
         $def = TypeScript::object();
         $def->key('methods')->value($verbs);
-        $def->key('url')->value($this->route->uri())->quote();
+        $def->key('url')->value($this->resolvedUrl())->quote();
 
         $this->addInertiaComponent($def);
 

--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Wayfinder\Registry;
 
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
@@ -91,6 +92,7 @@ class TypeScriptConverter extends AbstractConverter
 
         $matched = match (true) {
             $value->toString() === Stringable::class => 'string',
+            is_a($value->toString(), Carbon::class, true) => 'string',
             is_a($value->toString(), Collection::class, true) => $this->convertCollectionType($result),
             default => null,
         };

--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -89,9 +89,9 @@ class TypeScriptConverter extends AbstractConverter
     {
         $value = str($result->value)->ltrim('\\');
 
-        $matched = match ($value->toString()) {
-            Stringable::class => 'string',
-            Collection::class => 'unknown[]',
+        $matched = match (true) {
+            $value->toString() === Stringable::class => 'string',
+            is_a($value->toString(), Collection::class, true) => $this->convertCollectionType($result),
             default => null,
         };
 
@@ -110,6 +110,17 @@ class TypeScriptConverter extends AbstractConverter
         }
 
         return $this->decorate($matched, $result);
+    }
+
+    protected function convertCollectionType(Types\ClassType $result): string
+    {
+        $genericTypes = array_values($result->genericTypes());
+
+        return match (count($genericTypes)) {
+            0 => 'unknown[]',
+            1 => $this->convert($genericTypes[0]).'[]',
+            default => $this->convert($genericTypes[1]).'[]',
+        };
     }
 
     protected function convertNumberResult(Types\IntType|Types\FloatType|Types\NumberType $result): string

--- a/tests/EloquentProductController.test.ts
+++ b/tests/EloquentProductController.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, test } from "vitest";
+
+describe("EloquentProductController", () => {
+    const typesPath = join(
+        __dirname,
+        "../workbench/resources/js/wayfinder/types.d.ts",
+    );
+
+    test("types.d.ts contains EloquentProducts namespace under Inertia.Pages", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain("export namespace EloquentProducts");
+    });
+
+    test("Inertia.Pages.EloquentProducts.Index type is generated", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain("Inertia.Pages.EloquentProducts.Index");
+    });
+
+    test("Inertia.Pages.EloquentProducts.Index contains products: App.Models.Product[]", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain("products: App.Models.Product[]");
+    });
+
+    test("Inertia.Pages.EloquentProducts.Index does not contain products: Illuminate.Database.Eloquent.Collection", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).not.toContain(
+            "products: Illuminate.Database.Eloquent.Collection",
+        );
+    });
+
+    test("Inertia.Pages.EloquentProducts.Show type is generated", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain("Inertia.Pages.EloquentProducts.Show");
+    });
+
+    test("Inertia.Pages.EloquentProducts.Show contains product: App.Models.Product", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain("product: App.Models.Product");
+    });
+});

--- a/workbench/app/Http/Controllers/EloquentProductController.php
+++ b/workbench/app/Http/Controllers/EloquentProductController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StorePostRequest;
+use App\Models\Product;
+use Inertia\Inertia;
+
+class EloquentProductController
+{
+    public function index()
+    {
+        return Inertia::render('eloquent_products/index', [
+            'products' => Product::all(),
+        ]);
+    }
+
+    public function create()
+    {
+        //
+    }
+
+    public function store(StorePostRequest $request)
+    {
+        //
+    }
+
+    public function show(Product $product)
+    {
+        return Inertia::render('eloquent_products/show', [
+            'product' => $product,
+        ]);
+    }
+
+    public function edit()
+    {
+        //
+    }
+
+    public function update()
+    {
+        //
+    }
+
+    public function destroy()
+    {
+        //
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ResourceTestController;
 use App\Http\Controllers\DisallowedMethodNameController;
 use App\Http\Controllers\DomainController;
 use App\Http\Controllers\DuplicateInertiaController;
+use App\Http\Controllers\EloquentProductController;
 use App\Http\Controllers\InertiaController;
 use App\Http\Controllers\InvokableController;
 use App\Http\Controllers\InvokablePlusController;
@@ -41,6 +42,8 @@ Route::get('/posts/{post}', [PostController::class, 'show'])->name('posts.show')
 Route::get('/posts/{post}/edit', [PostController::class, 'edit'])->name('posts.edit');
 Route::patch('/posts/{post}', [PostController::class, 'update'])->name('posts.update');
 Route::delete('/posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
+
+Route::resource('eloquent_products', EloquentProductController::class);
 
 Route::get('/dashboard', function () {
     return 'Dashboard';


### PR DESCRIPTION
a fantastic new feature being introduced in wayfinder's `next` branch is the automatic generation of frontend types for Eloquent models being sent over-the-fence (<TODO: earmark and timestamp this> as Joe put it in the recent wayfinder demo video with Leah Thompson) from Laravel controller routes to Inertia frontends. 

in my humble experience, when backend schemas are in flux, end-to-end typesafety enforced by way of autogenerated type definitions has been a lifesaver. automation is the magic bullet that keeps it seamless. conversely, i've found that frontend type contracts fall out of sync pretty easily across teams when you have to remember to manually update them for every backend change.

when test driving wayfinder's `next` branch, this new wayfinder feature works great out of the box for a Laravel route with the following response shape:

```php
namespace App\Http\Controllers;

use App\Models\Product;
use Inertia\Inertia;

class ProductController extends Controller
{
    public function show(Product $product)
    {
        return Inertia::render('products/show', [
            'product' => $product,
        ]);
    }
}
```

with the above Laravel route, the corresponding Inertia page component props work flawlessly:

```tsx
import { Inertia } from '@/wayfinder/types';

export default function Show(props: Inertia.Pages.Products.Show) {
    const product = props.product;
    //    ^? const product: App.Models.Product;

    // more component code...
}
```

---

however, when Laravel routes return Eloquent Collections, something different occurs:

```php
namespace App\Http\Controllers;

use App\Models\Product;
use Inertia\Inertia;

class ProductController extends Controller
{
    public function index()
    {
        return Inertia::render('products/index', [
            'products' => Product::all(),
        ]);
    }
}
```

with the above Laravel route, the corresponding Inertia page component props are **not** type narrowed to the corresponding Eloquent model:

```tsx
import { Inertia } from '@/wayfinder/types';

export default function Index(props: Inertia.Pages.Products.Index) {
    const products = props.products;
    //    ^? const products: Illuminate.Database.Eloquent.Collection;

    products.map(product => console.log(product));
    // Compiler warning: Parameter 'product' implicitly has an any type.

    // more component code...
}

```

---

i was unable to find any existing "over-the-fence" typegen test coverage in the `next` branch, but i did find an existing Eloquent model called `Product` in this repo's Laravel test app, so i figured that'd be a great starting point to use for testing.

i added a Laravel controller to the test project, capturing the cases described above, and then added tests to ensure that the auto-generated `Inertia.Pages.Products.Index` frontend type definition contains `{ products: App.Models.Product[] }` and that the auto-generated `Inertia.Pages.Products.Show` frontend type definition contains `{ product: App.Models.Product }`
  - ✅ - testing expected typegen for `Inertia.Pages.Products.Show` passed
  - ❌ - testing expected typegen for `Inertia.Pages.Products.Index` did not pass

after doing some digging, the bug seems to live in `src/Registry/TypeScriptConverter.php`, in `convertClassResult()`. the method uses strict string equality to decide how to handle known class types, comparing against `Collection::class` which resolves to `Illuminate\Support\Collection`. that check never fires for `Illuminate\Database\Eloquent\Collection`, since the comparison isn't a subtype check, so Eloquent Collections fall through to the `default` case, which simply swaps backslashes for dots and returns the fully-qualified class name as a typescript identifier.

---

✅ achieving a passing `Inertia.Pages.Products.Index` typegen test necessitated replacing the strict equality check with `is_a($value->toString(), Collection::class, true)`; the third argument enables string class names and performs a proper subclass check. this means any subclass of `Illuminate\Support\Collection` is now handled by `convertCollectionType()`. that method unwraps the value generic and emits it as a typescript array type, giving the Inertia page component the fully narrowed prop:

```tsx
export default function Index(props: Inertia.Pages.Products.Index) {
    const products = props.products;
    //    ^? const products: App.Models.Product[];

    products.map(product => console.log(product));
    // no compiler warning for `product` anymore 🎉

    // more component code...
}
```

---

definition of done criteria:
- [x] `npm run test` passes locally
- [x] `composer format` passes locally