### PR TITLE
Bump Ranger version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,8 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11, 12, 13]
+        laravel: [12, 13]
         exclude:
-          - php: 8.5
-            laravel: 11
           - php: 8.2
             laravel: 13
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/filesystem": "^11.0|^12.0|^13.0",
         "illuminate/routing": "^11.0|^12.0|^13.0",
         "illuminate/support": "^11.0|^12.0|^13.0",
-        "laravel/ranger": "^0.2.0",
+        "laravel/ranger": "^0.2.2",
         "laravel/surveyor": "^0.2.1",
         "phpstan/phpdoc-parser": "^2.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/console": "^11.0|^12.0|^13.0",
-        "illuminate/filesystem": "^11.0|^12.0|^13.0",
-        "illuminate/routing": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/console": "^12.0|^13.0",
+        "illuminate/filesystem": "^12.0|^13.0",
+        "illuminate/routing": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0",
         "laravel/ranger": "^0.2.2",
         "laravel/surveyor": "^0.2.1",
         "phpstan/phpdoc-parser": "^2.3"
@@ -32,7 +32,7 @@
     "require-dev": {
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "^11.0|^10.1|^9.0"
+        "orchestra/testbench": "^10.1|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bump Ranger version to ^0.2.2 for the route domain fix, drop Laravel 11 from test matrix and composer.