### PR TITLE
Camel-case hyphenated directory names in barrel files

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -291,7 +291,7 @@ class GenerateCommand extends Command
         }
 
         $allImportNames = $files->merge($dirs)->map(fn ($name) => TypeScript::safeMethod($name, 'Method'));
-        $exportName = TypeScript::uniqueNamespace($dir->getBasename(), $allImportNames->toArray());
+        $exportName = TypeScript::uniqueNamespace(TypeScript::safeMethod($dir->getBasename(), 'Object'), $allImportNames->toArray());
 
         $exports = collect($imports->asLines())
             ->push('')

--- a/tests/HyphenatedBarrelExport.test.ts
+++ b/tests/HyphenatedBarrelExport.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "vitest";
+import dashedParent from "../workbench/resources/js/wayfinder/routes/dashed-parent";
+
+it("camel-cases hyphenated directory names in barrel files", () => {
+    expect(dashedParent.admin.items.url()).toBe("/dashed-parent/admin/items");
+    expect(dashedParent.admin.items()).toEqual({
+        url: "/dashed-parent/admin/items",
+        method: "get",
+    });
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -110,6 +110,10 @@ Route::prefix('/projects/application')->name('projects.application.')->group(fun
     Route::get('/customer-sector', fn () => 'ok')->name('customer-sector');
 });
 
+Route::prefix('/dashed-parent/admin')->name('dashed-parent.admin.')->group(function () {
+    Route::get('/items', fn () => 'ok')->name('items');
+});
+
 Route::prefix('/api/v1')->name('api.v1.')->group(function () {
     Route::get('/tasks', fn () => 'ok')->name('tasks');
 


### PR DESCRIPTION
The barrel file writer was using the directory basename as-is for the export identifier, so an intermediate route directory with a hyphen (e.g. filament resources like `central-heater/`) emitted invalid TypeScript: `export const central-heater = { ... }`. Other code paths already run the basename through `TypeScript::safeMethod(..., 'Object')`, so this just brings the barrel writer in line.

Closes #223
