### PR TITLE
Handle JS reserved keywords as enum case names

### DIFF
--- a/src/Converters/Enums.php
+++ b/src/Converters/Enums.php
@@ -31,6 +31,10 @@ class Enums extends Converter
         $content = [];
 
         foreach ($enum->cases as $case => $value) {
+            if (in_array($case, TypeScript::RESERVED_KEYWORDS, true)) {
+                continue;
+            }
+
             if (is_string($value)) {
                 $content[] = TypeScript::constant($case, TypeScript::quote($value))->export();
             } else {
@@ -40,9 +44,18 @@ class Enums extends Converter
 
         $content[] = '';
 
-        $obj = TypeScript::objectWithOnlyKeys(array_keys($enum->cases));
+        $obj = TypeScript::object()->inline();
 
-        $content[] = TypeScript::constant($name, $obj)
+        foreach ($enum->cases as $case => $value) {
+            if (in_array($case, TypeScript::RESERVED_KEYWORDS, true)) {
+                $literal = is_string($value) ? TypeScript::quote($value) : (string) $value;
+                $obj->key($case)->value($literal);
+            } else {
+                $obj->key($case)->value($case);
+            }
+        }
+
+        $content[] = TypeScript::constant($name, (string) $obj)
             ->export()
             ->asConst()
             ->link($enum->name, $enum->filepath());

--- a/src/Langs/TypeScript/ObjectBuilder.php
+++ b/src/Langs/TypeScript/ObjectBuilder.php
@@ -48,10 +48,7 @@ class ObjectBuilder implements Stringable
     public function __toString(): string
     {
         $object = '{';
-
-        if (! $this->inline) {
-            $object .= PHP_EOL;
-        }
+        $object .= $this->inline ? ' ' : PHP_EOL;
 
         $pairs = $this->inline
             ? $this->keyValuePairs

--- a/tests/Enums.test.ts
+++ b/tests/Enums.test.ts
@@ -6,6 +6,11 @@ import {
     Archived,
 } from "../workbench/resources/js/wayfinder/App/Enums/PostStatus";
 import { UnitEnum } from "../workbench/resources/js/wayfinder/App/Enums/UnitEnum";
+import {
+    ProductStatus,
+    used,
+    Active,
+} from "../workbench/resources/js/wayfinder/App/Enums/ProductStatus";
 
 describe("Enums", () => {
     test("exports enum constant object", () => {
@@ -47,5 +52,26 @@ describe("Enums", () => {
         expect(Draft).toBe("draft");
         expect(Published).toBe("published");
         expect(Archived).toBe("archived");
+    });
+
+    test("handles reserved keyword case names", () => {
+        expect(ProductStatus.new).toBe("new");
+        expect(ProductStatus.used).toBe("used");
+        expect(ProductStatus.for).toBe("for-sale");
+        expect(ProductStatus.Active).toBe("active");
+    });
+
+    test("exposes all keys for enums with reserved keyword cases", () => {
+        expect(Object.keys(ProductStatus)).toEqual([
+            "new",
+            "used",
+            "for",
+            "Active",
+        ]);
+    });
+
+    test("only exports non-reserved case constants individually", () => {
+        expect(used).toBe("used");
+        expect(Active).toBe("active");
     });
 });

--- a/tests/ResourceData.test.ts
+++ b/tests/ResourceData.test.ts
@@ -59,7 +59,7 @@ describe("ResourceData", () => {
     test("JsonApiResource relationships emit cardinality-aware shapes", () => {
         // to-one is { data: { id, type } | null }, to-many is { data: { id, type }[] }
         expect(types()).toContain(
-            "relationships?: { featuredProduct: {data: {id: string, type: string } | null }, relatedProducts: {data: {id: string, type: string }[] } }"
+            "relationships?: { featuredProduct: { data: { id: string, type: string } | null }, relatedProducts: { data: { id: string, type: string }[] } }"
         );
     });
 });

--- a/workbench/app/Enums/ProductStatus.php
+++ b/workbench/app/Enums/ProductStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum ProductStatus: string
+{
+    case new = 'new';
+    case used = 'used';
+    case for = 'for-sale';
+    case Active = 'active';
+}


### PR DESCRIPTION
PHP enums whose case names collide with JS reserved keywords (e.g. `case new`) produced invalid TypeScript: `export const new = "new"` is a syntax error, and `{ new, used }` shorthand fails because shorthand property names cannot be reserved words.

For reserved-keyword cases we now skip the individual `export const` (you cannot import a reserved word anyway) and emit the combined object with explicit `key: literal` pairs. Non-reserved cases still get their shorthand form, so existing enum output is unchanged. Inline `ObjectBuilder` rendering also picks up a leading space so it is symmetric with its trailing one.

Closes #206
