### PR TITLE
Fix inertia-config.d.ts breaking @inertiajs/core type augmentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.29.0",
+        "@inertiajs/core": "^3.1.0",
         "@types/node": "^22.7.5",
         "eslint": "^9.29.0",
         "happy-dom": ">=20.0.2",

--- a/src/Converters/InertiaSharedData.php
+++ b/src/Converters/InertiaSharedData.php
@@ -45,13 +45,13 @@ class InertiaSharedData extends Converter
 
         preg_match_all('/(?<!\.)([A-Z][a-zA-Z0-9]*)(?=\.[A-Z])/', $typeObject, $matches);
 
-        $imports = [];
+        $importsHelper = Imports::create()->addSideEffect('@inertiajs/core');
 
         if (count($matches[0]) > 0) {
-            $imports[] = (string) Imports::create()->add('./types', $matches[0]);
-            $imports[] = '';
-            $imports[] = '';
+            $importsHelper->add('./types', $matches[0]);
         }
+
+        $imports = [(string) $importsHelper, '', ''];
 
         $module = TypeScript::module(
             '@inertiajs/core',

--- a/src/Langs/TypeScript/Imports.php
+++ b/src/Langs/TypeScript/Imports.php
@@ -10,9 +10,20 @@ class Imports implements Stringable
 {
     public array $imports = [];
 
+    public array $sideEffects = [];
+
     public static function create(): self
     {
         return new self;
+    }
+
+    public function addSideEffect(string $from): self
+    {
+        if (! in_array($from, $this->sideEffects, true)) {
+            $this->sideEffects[] = $from;
+        }
+
+        return $this;
     }
 
     public function addImport(Import $import): self
@@ -158,6 +169,10 @@ class Imports implements Stringable
     public function asLines(): array
     {
         $lines = [];
+
+        foreach ($this->sideEffects as $from) {
+            $lines[] = sprintf('import "%s";', $from);
+        }
 
         foreach ($this->imports as $from => $imports) {
             $default = null;

--- a/tests/InertiaSharedData.test.ts
+++ b/tests/InertiaSharedData.test.ts
@@ -28,6 +28,11 @@ describe("InertiaSharedData", () => {
         expect(content).toContain("declare module '@inertiajs/core'");
     });
 
+    test("inertia-config.d.ts imports @inertiajs/core so the file is treated as a module for augmentation", () => {
+        const content = readFileSync(inertiaConfigPath, "utf-8");
+        expect(content).toContain('import "@inertiajs/core";');
+    });
+
     test("inertia-config.d.ts exports InertiaConfig interface", () => {
         const content = readFileSync(inertiaConfigPath, "utf-8");
         expect(content).toContain("export interface InertiaConfig");

--- a/tsconfig.wayfinder.json
+++ b/tsconfig.wayfinder.json
@@ -1,8 +1,5 @@
 {
     "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "skipLibCheck": false
-    },
     "include": [
         "workbench/resources/js/wayfinder/**/*.d.ts"
     ]


### PR DESCRIPTION
The generated inertia-config.d.ts had no top-level import or export, so TypeScript treated it as a script rather than a module. That meant the `declare module '@inertiajs/core'` block replaced the real module instead of augmenting it, wiping out exports like `useFormContext`.

Added an `addSideEffect()` method to the Imports helper and used it from InertiaSharedData to emit `import "@inertiajs/core";` at the top of the generated file. That makes it a module so the declaration merges as intended.

Closes #178
