### PR TITLE
Generate concrete types for resources nested in Inertia data

### DIFF
--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -20,6 +20,7 @@ class TypeScriptConverter extends AbstractConverter
             Types\ArrayShapeType::class => $this->convertArrayShapeResult($result),
             Types\BoolType::class => $this->convertBoolResult($result),
             Types\ClassType::class => $this->convertClassResult($result),
+            Types\Entities\ResourceResponse::class => $this->convertResourceResponse($result),
             Types\IntType::class, Types\FloatType::class, Types\NumberType::class => $this->convertNumberResult($result),
             Types\IntersectionType::class => $this->convertIntersectionResult($result),
             Types\MixedType::class => $this->convertMixedResult($result),
@@ -29,6 +30,19 @@ class TypeScriptConverter extends AbstractConverter
             Types\CallableType::class => $this->convertCallableResult($result),
             default => throw new InvalidArgumentException('Unsupported result type: '.get_class($result)),
         };
+    }
+
+    protected function convertResourceResponse(Types\Entities\ResourceResponse $result): string
+    {
+        // Inertia/array contexts call ->toArray() directly without the JSON wrap,
+        // so emit just the data shape.
+        $shape = $result->data instanceof Types\ArrayType
+            ? TypeScript::objectToTypeObject($result->data->value, false)
+            : $this->convert($result->data);
+
+        $shape = (string) $shape;
+
+        return $result->isCollection ? "{$shape}[]" : $shape;
     }
 
     protected function convertCallableResult(Types\CallableType $result): string

--- a/tests/InertiaDataResource.test.ts
+++ b/tests/InertiaDataResource.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, test } from "vitest";
+
+describe("InertiaData with API Resources", () => {
+    const typesPath = join(
+        __dirname,
+        "../workbench/resources/js/wayfinder/types.d.ts"
+    );
+
+    test("a UserResource::collection() in Inertia data generates a typed array", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain(
+            "export type UsersList = Inertia.SharedData & { users: { id: number, name: string, email: string }[], featured: { id: number, name: string, email: string } }"
+        );
+    });
+
+    test("does not leak the AnonymousResourceCollection class name", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).not.toContain("AnonymousResourceCollection");
+    });
+});

--- a/workbench/app/Http/Controllers/InertiaController.php
+++ b/workbench/app/Http/Controllers/InertiaController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\UserResource;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -16,6 +17,14 @@ class InertiaController
                 'views' => 10000,
             ],
             'recentActivity' => [],
+        ]);
+    }
+
+    public function usersList(): Response
+    {
+        return Inertia::render('UsersList', [
+            'users' => UserResource::collection([]),
+            'featured' => new UserResource(null),
         ]);
     }
 

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -127,6 +127,7 @@ Route::get('/inertia/settings', [InertiaController::class, 'settings'])->name('i
 Route::get('/inertia/profile', [InertiaController::class, 'profile'])->name('inertia.profile');
 Route::get('/inertia/unsafe', [InertiaController::class, 'unsafe'])->name('inertia.unsafe');
 Route::get('/inertia/conditional', [InertiaController::class, 'conditional'])->name('inertia.conditional');
+Route::get('/inertia/users-list', [InertiaController::class, 'usersList'])->name('inertia.users-list');
 
 Route::get('/inertia/modular/login', [ModularInertiaController::class, 'login'])->name('inertia.modular.login');
 Route::get('/inertia/modular/register', [ModularInertiaController::class, 'register'])->name('inertia.modular.register');


### PR DESCRIPTION
When a `Resource::collection()` or `new Resource(...)` showed up inside an `Inertia::render()` data array, the generated type was `Illuminate.Http.Resources.Json.AnonymousResourceCollection` instead of the actual resource shape. Inertia calls `->toArray()` directly on these values, so the JSON wrap doesn't apply and we should emit the unwrapped shape.

Adds `convertResourceResponse` and `convertJsonApiResourceResponse` to `TypeScriptConverter` so a nested `UserResource::collection(...)` becomes `{ id: number, name: string, email: string }[]` and a nested `new UserResource(...)` becomes `{ id: number, name: string, email: string }`. Top-level controller returns are unchanged, those still flow through `ResourceData::convert` and keep their `{ data: ... }` wrap.

Depends on the matching surveyor change to stop polluting the union with `AnonymousResourceCollection`.

Fixes #158
