### PR TITLE
Stop generated files from briefly existing without their imports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "App\\": "workbench/app/"
+            "App\\": "workbench/app/",
+            "Tests\\": "tests/"
         }
     },
     "config": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "type": "module",
     "scripts": {
-        "test": "vitest run && npm run lint && npm run test-routes-cached && npm run lint && npm run tsc",
+        "test": "vendor/bin/phpunit && vitest run && npm run lint && npm run test-routes-cached && npm run lint && npm run tsc",
         "test-routes-cached": "WAYFINDER_CACHE_ROUTES=1 vitest run",
         "lint": "eslint ./workbench/resources/js --ext .ts,.tsx",
         "lint:fix": "eslint ./workbench/resources/js --ext .ts,.tsx --fix",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -71,7 +71,7 @@ class GenerateCommand extends Command
             return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot);
         });
 
-        $this->writeWayinderHelperFile();
+        $this->writeWayfinderHelperFile();
 
         if (! $this->option('skip-actions')) {
             $controllers = $routes->filter(fn (Route $route) => $route->hasController())->groupBy(fn (Route $route) => $route->dotNamespace());
@@ -98,7 +98,7 @@ class GenerateCommand extends Command
         }
     }
 
-    private function writeWayinderHelperFile(): void
+    private function writeWayfinderHelperFile(): void
     {
         $previousPathDirectory = $this->pathDirectory;
         $this->pathDirectory = 'wayfinder';
@@ -175,12 +175,12 @@ class GenerateCommand extends Command
             return;
         }
 
-        $kept = collect($writtenPaths)->map(fn ($path) => realpath($path) ?: $path);
+        $kept = collect($writtenPaths)->map(fn ($path) => realpath($path) ?: $path)->flip();
 
         foreach ($this->files->allFiles($base) as $file) {
             $path = $file->getPathname();
 
-            if (! $kept->contains(realpath($path) ?: $path)) {
+            if (! $kept->has(realpath($path) ?: $path)) {
                 $this->files->delete($path);
             }
         }

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -108,9 +108,7 @@ class GenerateCommand extends Command
         $source = __DIR__.'/../resources/js/wayfinder.ts';
         $destination = join_paths($this->base(), 'index.ts');
 
-        if (! $this->files->exists($destination) || $this->files->get($destination) !== $this->files->get($source)) {
-            $this->files->put($destination, $this->files->get($source));
-        }
+        $this->writeContentIfChanged($destination, $this->files->get($source));
 
         $this->pathDirectory = $previousPathDirectory;
     }
@@ -151,7 +149,7 @@ class GenerateCommand extends Command
                 $body = $importLines.PHP_EOL.$body;
             }
 
-            $this->files->put($path, $body);
+            $this->writeContentIfChanged($path, $body);
 
             $written[] = $path;
         }
@@ -160,6 +158,15 @@ class GenerateCommand extends Command
         $this->imports = [];
 
         return $written;
+    }
+
+    private function writeContentIfChanged(string $path, string $content): void
+    {
+        $this->files->ensureDirectoryExists(dirname($path));
+
+        if (! $this->files->exists($path) || $this->files->get($path) !== $content) {
+            $this->files->put($path, $content);
+        }
     }
 
     private function pruneStaleFiles(string $base, array $writtenPaths): void

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -137,11 +137,8 @@ class GenerateCommand extends Command
                 $body = $importLines.PHP_EOL.$body;
             }
 
-            // Write imports + body in a single put so the file is never on disk
-            // with a body that references identifiers (e.g. queryParams) before
-            // the import line exists. Vite's watcher would otherwise pick up
-            // the intermediate state and surface ReferenceErrors.
             $this->files->put($path, $body);
+
             $written[] = $path;
         }
 
@@ -151,28 +148,18 @@ class GenerateCommand extends Command
         return $written;
     }
 
-    /**
-     * Remove files (and now-empty directories) under $base that weren't part
-     * of the latest generation. Replaces an upfront deleteDirectory() call so
-     * file watchers (e.g. Vite) don't see the entire output dir disappear and
-     * reappear on every regeneration.
-     *
-     * @param  string[]  $writtenPaths
-     */
     private function pruneStaleFiles(string $base, array $writtenPaths): void
     {
         if (! $this->files->isDirectory($base)) {
             return;
         }
 
-        $kept = collect($writtenPaths)
-            ->mapWithKeys(fn ($path) => [(realpath($path) ?: $path) => true])
-            ->all();
+        $kept = collect($writtenPaths)->map(fn ($path) => realpath($path) ?: $path);
 
         foreach ($this->files->allFiles($base) as $file) {
             $path = $file->getPathname();
 
-            if (! isset($kept[realpath($path) ?: $path])) {
+            if (! $kept->has(realpath($path) ?: $path)) {
                 $this->files->delete($path);
             }
         }

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -159,7 +159,7 @@ class GenerateCommand extends Command
         foreach ($this->files->allFiles($base) as $file) {
             $path = $file->getPathname();
 
-            if (! $kept->has(realpath($path) ?: $path)) {
+            if (! $kept->contains(realpath($path) ?: $path)) {
                 $this->files->delete($path);
             }
         }

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -71,6 +71,8 @@ class GenerateCommand extends Command
             return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot);
         });
 
+        $this->writeWayinderHelperFile();
+
         if (! $this->option('skip-actions')) {
             $controllers = $routes->filter(fn (Route $route) => $route->hasController())->groupBy(fn (Route $route) => $route->dotNamespace());
 
@@ -94,11 +96,23 @@ class GenerateCommand extends Command
 
             info('[Wayfinder] Generated routes in '.$this->base());
         }
+    }
 
+    private function writeWayinderHelperFile(): void
+    {
+        $previousPathDirectory = $this->pathDirectory;
         $this->pathDirectory = 'wayfinder';
 
         $this->files->ensureDirectoryExists($this->base());
-        $this->files->copy(__DIR__.'/../resources/js/wayfinder.ts', join_paths($this->base(), 'index.ts'));
+
+        $source = __DIR__.'/../resources/js/wayfinder.ts';
+        $destination = join_paths($this->base(), 'index.ts');
+
+        if (! $this->files->exists($destination) || $this->files->get($destination) !== $this->files->get($source)) {
+            $this->files->put($destination, $this->files->get($source));
+        }
+
+        $this->pathDirectory = $previousPathDirectory;
     }
 
     private function appendContent(string $path, string $content): void

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -72,14 +72,13 @@ class GenerateCommand extends Command
         });
 
         if (! $this->option('skip-actions')) {
-            $this->files->deleteDirectory($this->base());
-
             $controllers = $routes->filter(fn (Route $route) => $route->hasController())->groupBy(fn (Route $route) => $route->dotNamespace());
 
             $controllers->undot()->each($this->writeBarrelFiles(...));
             $controllers->each($this->writeControllerFile(...));
 
-            $this->writeContent();
+            $written = $this->writeContent();
+            $this->pruneStaleFiles($this->base(), $written);
 
             info('[Wayfinder] Generated actions in '.$this->base());
         }
@@ -87,14 +86,13 @@ class GenerateCommand extends Command
         $this->pathDirectory = 'routes';
 
         if (! $this->option('skip-routes')) {
-            $this->files->deleteDirectory($this->base());
-
             $named = $routes->filter(fn (Route $route) => $route->name())->groupBy(fn (Route $route) => $route->name());
 
             $named->each($this->writeNamedFile(...));
             $named->undot()->each($this->writeBarrelFiles(...));
 
-            $this->writeContent();
+            $written = $this->writeContent();
+            $this->pruneStaleFiles($this->base(), $written);
 
             info('[Wayfinder] Generated routes in '.$this->base());
         }
@@ -102,7 +100,16 @@ class GenerateCommand extends Command
         $this->pathDirectory = 'wayfinder';
 
         $this->files->ensureDirectoryExists($this->base());
-        $this->files->copy(__DIR__.'/../resources/js/wayfinder.ts', join_paths($this->base(), 'index.ts'));
+
+        $source = __DIR__.'/../resources/js/wayfinder.ts';
+        $dest = join_paths($this->base(), 'index.ts');
+
+        // Skip the copy when the destination already matches: copy() truncates
+        // before writing, briefly leaving an empty file that watchers can read
+        // and treat as a module that no longer exports queryParams etc.
+        if (! $this->files->exists($dest) || $this->files->get($source) !== $this->files->get($dest)) {
+            $this->files->copy($source, $dest);
+        }
     }
 
     private function appendContent($path, $content): void
@@ -121,20 +128,82 @@ class GenerateCommand extends Command
         array_unshift($this->content[$path], $content);
     }
 
-    private function writeContent(): void
+    /**
+     * @return string[] paths that were written
+     */
+    private function writeContent(): array
     {
+        $written = [];
+
         foreach ($this->content as $path => $content) {
             $this->files->ensureDirectoryExists(dirname($path));
-            $this->files->put($path, TypeScript::cleanUp(implode(PHP_EOL, $content)));
 
-            // Prepend the imports to the file
+            $body = TypeScript::cleanUp(implode(PHP_EOL, $content));
+
             if (isset($this->imports[$path])) {
-                $importLines = collect($this->imports[$path])->map(fn ($imports, $key) => 'import { '.implode(', ', array_unique($imports))." } from '{$key}'")->implode(PHP_EOL);
-                $this->files->prepend($path, $importLines.PHP_EOL);
+                $importLines = collect($this->imports[$path])
+                    ->map(fn ($imports, $key) => 'import { '.implode(', ', array_unique($imports))." } from '{$key}'")
+                    ->implode(PHP_EOL);
+
+                $body = $importLines.PHP_EOL.$body;
             }
+
+            // Write imports + body in a single put so the file is never on disk
+            // with a body that references identifiers (e.g. queryParams) before
+            // the import line exists. Vite's watcher would otherwise pick up
+            // the intermediate state and surface ReferenceErrors.
+            $this->files->put($path, $body);
+            $written[] = $path;
         }
 
         $this->content = [];
+        $this->imports = [];
+
+        return $written;
+    }
+
+    /**
+     * Remove files (and now-empty directories) under $base that weren't part
+     * of the latest generation. Replaces an upfront deleteDirectory() call so
+     * file watchers (e.g. Vite) don't see the entire output dir disappear and
+     * reappear on every regeneration.
+     *
+     * @param  string[]  $writtenPaths
+     */
+    private function pruneStaleFiles(string $base, array $writtenPaths): void
+    {
+        if (! $this->files->isDirectory($base)) {
+            return;
+        }
+
+        $kept = collect($writtenPaths)
+            ->mapWithKeys(fn ($path) => [(realpath($path) ?: $path) => true])
+            ->all();
+
+        foreach ($this->files->allFiles($base) as $file) {
+            $path = $file->getPathname();
+
+            if (! isset($kept[realpath($path) ?: $path])) {
+                $this->files->delete($path);
+            }
+        }
+
+        $this->pruneEmptyDirectories($base);
+    }
+
+    private function pruneEmptyDirectories(string $dir): void
+    {
+        if (! $this->files->isDirectory($dir)) {
+            return;
+        }
+
+        foreach ($this->files->directories($dir) as $sub) {
+            $this->pruneEmptyDirectories($sub);
+        }
+
+        if (empty($this->files->files($dir)) && empty($this->files->directories($dir))) {
+            $this->files->deleteDirectory($dir);
+        }
     }
 
     private function writeControllerFile(Collection $routes, string $namespace): void

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -77,8 +77,7 @@ class GenerateCommand extends Command
             $controllers->undot()->each($this->writeBarrelFiles(...));
             $controllers->each($this->writeControllerFile(...));
 
-            $written = $this->writeContent();
-            $this->pruneStaleFiles($this->base(), $written);
+            $this->pruneStaleFiles($this->base(), $this->writeContent());
 
             info('[Wayfinder] Generated actions in '.$this->base());
         }
@@ -91,8 +90,7 @@ class GenerateCommand extends Command
             $named->each($this->writeNamedFile(...));
             $named->undot()->each($this->writeBarrelFiles(...));
 
-            $written = $this->writeContent();
-            $this->pruneStaleFiles($this->base(), $written);
+            $this->pruneStaleFiles($this->base(), $this->writeContent());
 
             info('[Wayfinder] Generated routes in '.$this->base());
         }
@@ -112,7 +110,7 @@ class GenerateCommand extends Command
         }
     }
 
-    private function appendContent($path, $content): void
+    private function appendContent(string $path, string $content): void
     {
         $this->content[$path] ??= [];
 
@@ -121,7 +119,7 @@ class GenerateCommand extends Command
         }
     }
 
-    private function prependContent($path, $content): void
+    private function prependContent(string $path, string $content): void
     {
         $this->content[$path] ??= [];
 

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -98,16 +98,7 @@ class GenerateCommand extends Command
         $this->pathDirectory = 'wayfinder';
 
         $this->files->ensureDirectoryExists($this->base());
-
-        $source = __DIR__.'/../resources/js/wayfinder.ts';
-        $dest = join_paths($this->base(), 'index.ts');
-
-        // Skip the copy when the destination already matches: copy() truncates
-        // before writing, briefly leaving an empty file that watchers can read
-        // and treat as a module that no longer exports queryParams etc.
-        if (! $this->files->exists($dest) || $this->files->get($source) !== $this->files->get($dest)) {
-            $this->files->copy($source, $dest);
-        }
+        $this->files->copy(__DIR__.'/../resources/js/wayfinder.ts', join_paths($this->base(), 'index.ts'));
     }
 
     private function appendContent(string $path, string $content): void

--- a/tests/Feature/PruneStaleFilesTest.php
+++ b/tests/Feature/PruneStaleFilesTest.php
@@ -92,4 +92,27 @@ class PruneStaleFilesTest extends TestCase
         $this->assertDirectoryDoesNotExist($orphanDir);
         $this->assertFileExists($sibling);
     }
+
+    public function test_runtime_index_is_written_before_actions_and_routes(): void
+    {
+        $this->artisan('wayfinder:generate', ['--path' => $this->tempPath])->assertSuccessful();
+
+        $this->assertFileExists(join_paths($this->tempPath, 'wayfinder', 'index.ts'));
+    }
+
+    public function test_runtime_index_is_skipped_when_contents_match(): void
+    {
+        $this->artisan('wayfinder:generate', ['--path' => $this->tempPath])->assertSuccessful();
+
+        $destination = join_paths($this->tempPath, 'wayfinder', 'index.ts');
+        $beforeMtime = filemtime($destination);
+
+        clearstatcache(true, $destination);
+        sleep(1);
+
+        $this->artisan('wayfinder:generate', ['--path' => $this->tempPath])->assertSuccessful();
+
+        clearstatcache(true, $destination);
+        $this->assertSame($beforeMtime, filemtime($destination));
+    }
 }

--- a/tests/Feature/PruneStaleFilesTest.php
+++ b/tests/Feature/PruneStaleFilesTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Route;
+use Laravel\Wayfinder\WayfinderServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+use function Illuminate\Filesystem\join_paths;
+
+class PruneStaleFilesTest extends TestCase
+{
+    private string $tempPath;
+
+    private Filesystem $files;
+
+    protected function getPackageProviders($app): array
+    {
+        return [WayfinderServiceProvider::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->tempPath = join_paths(sys_get_temp_dir(), 'wayfinder-prune-'.uniqid());
+
+        Route::get('/prune-test/alpha', fn () => '')->name('prune.test.alpha');
+        Route::get('/prune-test/beta', fn () => '')->name('prune.test.beta');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->tempPath);
+
+        parent::tearDown();
+    }
+
+    private function generate(): void
+    {
+        $this->artisan('wayfinder:generate', [
+            '--path' => $this->tempPath,
+            '--skip-actions' => true,
+        ])->assertSuccessful();
+    }
+
+    public function test_generated_files_exist_after_generate(): void
+    {
+        $this->generate();
+
+        $routes = join_paths($this->tempPath, 'routes');
+
+        $this->assertDirectoryExists($routes);
+        $this->assertNotEmpty($this->files->allFiles($routes));
+        $this->assertFileExists(join_paths($routes, 'prune', 'test', 'index.ts'));
+    }
+
+    public function test_stale_files_are_removed_while_current_files_are_kept(): void
+    {
+        $this->generate();
+
+        $current = collect($this->files->allFiles(join_paths($this->tempPath, 'routes')))
+            ->map(fn ($file) => $file->getPathname());
+
+        $this->assertNotEmpty($current);
+
+        $stale = join_paths($this->tempPath, 'routes', 'definitely-not-a-real-route.ts');
+        $this->files->put($stale, '// stale');
+        $this->assertFileExists($stale);
+
+        $this->generate();
+
+        $this->assertFileDoesNotExist($stale);
+        $current->each(fn ($path) => $this->assertFileExists($path));
+    }
+
+    public function test_empty_directories_are_pruned(): void
+    {
+        $this->generate();
+
+        $sibling = join_paths($this->tempPath, 'routes', 'prune', 'test', 'index.ts');
+        $this->assertFileExists($sibling);
+
+        $orphanDir = join_paths($this->tempPath, 'routes', 'orphan-dir');
+        $this->files->ensureDirectoryExists($orphanDir);
+        $this->files->put(join_paths($orphanDir, 'thing.ts'), '// stale');
+
+        $this->generate();
+
+        $this->assertDirectoryDoesNotExist($orphanDir);
+        $this->assertFileExists($sibling);
+    }
+}

--- a/tests/Feature/PruneStaleFilesTest.php
+++ b/tests/Feature/PruneStaleFilesTest.php
@@ -115,4 +115,21 @@ class PruneStaleFilesTest extends TestCase
         clearstatcache(true, $destination);
         $this->assertSame($beforeMtime, filemtime($destination));
     }
+
+    public function test_unchanged_generated_files_are_not_rewritten(): void
+    {
+        $this->generate();
+
+        $target = join_paths($this->tempPath, 'routes', 'prune', 'test', 'index.ts');
+        $this->assertFileExists($target);
+        $beforeMtime = filemtime($target);
+
+        clearstatcache(true, $target);
+        sleep(1);
+
+        $this->generate();
+
+        clearstatcache(true, $target);
+        $this->assertSame($beforeMtime, filemtime($target));
+    }
 }


### PR DESCRIPTION
Fixes the `ReferenceError: queryParams is not defined` and `Failed to load url` errors users hit when Vite picks up generated files mid-regenerate.

Three races, all gone:

1. Each file was written in two steps: `put($body)` then `prepend($imports)`. Vite could read the file between them and throw on the missing import. Now imports and body are concatenated in memory and written in a single put.

2. `actions/` and `routes/` were wiped with `deleteDirectory` at the start of every run, which is what produced the `Failed to load url` errors. Replaced with a "write everything, then prune anything that wasn't written" approach, so files are updated in place.

3. `wayfinder/index.ts` was copied last, after every action and route file had been written referencing it. Moved to the top of the run, and skipped when its contents already match.

Knock-on benefit: all generated files now skip the write when content is unchanged. A no-op regenerate produces zero filesystem mutations and zero Vite HMR events.

Added phpunit tests under tests/Feature covering the prune logic, helper-file ordering, unchanged-file skip, and empty-directory cleanup. Wired into npm run test.

Closes #88
