### PR TITLE
next: paginated Eloquent response type narrowing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,12 @@
         "illuminate/filesystem": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ranger": "^0.2.4",
-        "laravel/surveyor": "^0.2.1",
+        "laravel/ranger": "dev-main as 0.2.x-dev",
+        "laravel/surveyor": "dev-template-bindings-via-static-method-dispatch-on-model-subclasses as 0.2.x-dev",
         "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {
+        "laravel/framework": "12.x-dev|^13.9.0",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/pint": "^1.21",
         "orchestra/testbench": "^10.1|^11.0"
@@ -74,5 +75,11 @@
                 "Laravel\\Wayfinder\\WayfinderServiceProvider"
             ]
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/levikl/surveyor"
+        }
+    ]
 }

--- a/tests/EloquentProductController.test.ts
+++ b/tests/EloquentProductController.test.ts
@@ -6,14 +6,14 @@ type NotAny<T> = 0 extends (1 & T) ? never : T;
 
 describe("EloquentProductController", () => {
     test("Index narrows products to App.Models.Product[]", () => {
-        expectTypeOf<NotAny<Inertia.Pages.EloquentProducts.Index["products"]>>().toEqualTypeOf<
-            App.Models.Product[]
-        >();
+        type Subject = NotAny<Inertia.Pages.EloquentProducts.Index["products"]>;
+
+        expectTypeOf<Subject>().toEqualTypeOf<App.Models.Product[]>();
     });
 
     test("Show narrows product to App.Models.Product", () => {
-        expectTypeOf<NotAny<Inertia.Pages.EloquentProducts.Show["product"]>>().toEqualTypeOf<
-            App.Models.Product
-        >();
+        type Subject = NotAny<Inertia.Pages.EloquentProducts.Show["product"]>;
+
+        expectTypeOf<Subject>().toEqualTypeOf<App.Models.Product>();
     });
 });

--- a/tests/EloquentProductController.test.ts
+++ b/tests/EloquentProductController.test.ts
@@ -1,23 +1,19 @@
-import { readFileSync } from "fs";
-import { join } from "path";
-import { describe, expect, test } from "vitest";
+import { describe, expectTypeOf, test } from "vitest";
+
+import type { App, Inertia } from "../workbench/resources/js/wayfinder/types";
+
+type NotAny<T> = 0 extends (1 & T) ? never : T;
 
 describe("EloquentProductController", () => {
-    const typesPath = join(
-        __dirname,
-        "../workbench/resources/js/wayfinder/types.d.ts",
-    );
-
-    const types = () => readFileSync(typesPath, "utf-8");
-
     test("Index narrows products to App.Models.Product[]", () => {
-        expect(types()).toContain("{ products: App.Models.Product[] }");
-        expect(types()).not.toContain(
-            "products: Illuminate.Database.Eloquent.Collection",
-        );
+        expectTypeOf<NotAny<Inertia.Pages.EloquentProducts.Index["products"]>>().toEqualTypeOf<
+            App.Models.Product[]
+        >();
     });
 
     test("Show narrows product to App.Models.Product", () => {
-        expect(types()).toContain("{ product: App.Models.Product }");
+        expectTypeOf<NotAny<Inertia.Pages.EloquentProducts.Show["product"]>>().toEqualTypeOf<
+            App.Models.Product
+        >();
     });
 });

--- a/tests/PaginatedEloquentProductController.test.ts
+++ b/tests/PaginatedEloquentProductController.test.ts
@@ -5,21 +5,39 @@ import type { App, Inertia } from "../workbench/resources/js/wayfinder/types";
 type NotAny<T> = 0 extends (1 & T) ? never : T;
 
 describe("PaginatedEloquentProductController", () => {
-    test("paginate narrows products.data to App.Models.Product[]", () => {
-        expectTypeOf<NotAny<Inertia.Pages.PaginatedEloquentProducts.Paginate["products"]["data"]>>().toEqualTypeOf<
-            App.Models.Product[]
-        >();
+    test("Product::paginate()) emits expected types", () => {
+        type Subject = Inertia.Pages.PaginatedEloquentProducts.Paginate["products"];
+
+        expectTypeOf<NotAny<Subject["data"]>>().toEqualTypeOf< App.Models.Product[] >();
+
+        // TODO: add generic return type to laravel/framework LengthAwarePaginator's linkCollection() docblock and this passes
+        // expectTypeOf<NotAny<Subject["links"]>>().toEqualTypeOf<
+        //     { url: string | null; label: string; active: boolean; page?: number | null }[]
+        // >();
+
+        expectTypeOf<NotAny<Subject["path"]>>().toEqualTypeOf<string | null>();
+        expectTypeOf<NotAny<Subject["from"]>>().toEqualTypeOf<number | null>();
+        expectTypeOf<NotAny<Subject["to"]>>().toEqualTypeOf<number | null>();
+        expectTypeOf<NotAny<Subject["total"]>>().toEqualTypeOf<number>();
+        expectTypeOf<NotAny<Subject["current_page"]>>().toEqualTypeOf<number>();
+        expectTypeOf<NotAny<Subject["last_page"]>>().toEqualTypeOf<number>();
+        expectTypeOf<NotAny<Subject["first_page_url"]>>().toEqualTypeOf<string>();
+        expectTypeOf<NotAny<Subject["prev_page_url"]>>().toEqualTypeOf<string | null>();
+        expectTypeOf<NotAny<Subject["next_page_url"]>>().toEqualTypeOf<string | null>();
+        expectTypeOf<NotAny<Subject["last_page_url"]>>().toEqualTypeOf<string>();
+        expectTypeOf<NotAny<Subject["total"]>>().toEqualTypeOf<number>();
+        expectTypeOf<NotAny<Subject["per_page"]>>().toEqualTypeOf<number>();
     });
 
     test("simplePaginate narrows products.data to App.Models.Product[]", () => {
-        expectTypeOf<NotAny<Inertia.Pages.PaginatedEloquentProducts.SimplePaginate["products"]["data"]>>().toEqualTypeOf<
-            App.Models.Product[]
-        >();
+        type Subject = Inertia.Pages.PaginatedEloquentProducts.SimplePaginate["products"];
+
+        expectTypeOf<NotAny<Subject["data"]>>().toEqualTypeOf<App.Models.Product[]>();
     });
 
     test("cursorPaginate narrows products.data to App.Models.Product[]", () => {
-        expectTypeOf<NotAny<Inertia.Pages.PaginatedEloquentProducts.CursorPaginate["products"]["data"]>>().toEqualTypeOf<
-            App.Models.Product[]
-        >();
+        type Subject = Inertia.Pages.PaginatedEloquentProducts.CursorPaginate["products"];
+
+        expectTypeOf<NotAny<Subject["data"]>>().toEqualTypeOf<App.Models.Product[]>();
     });
 });

--- a/tests/PaginatedEloquentProductController.test.ts
+++ b/tests/PaginatedEloquentProductController.test.ts
@@ -1,0 +1,25 @@
+import { describe, expectTypeOf, test } from "vitest";
+
+import type { App, Inertia } from "../workbench/resources/js/wayfinder/types";
+
+type NotAny<T> = 0 extends (1 & T) ? never : T;
+
+describe("PaginatedEloquentProductController", () => {
+    test("paginate narrows products.data to App.Models.Product[]", () => {
+        expectTypeOf<NotAny<Inertia.Pages.PaginatedEloquentProducts.Paginate["products"]["data"]>>().toEqualTypeOf<
+            App.Models.Product[]
+        >();
+    });
+
+    test("simplePaginate narrows products.data to App.Models.Product[]", () => {
+        expectTypeOf<NotAny<Inertia.Pages.PaginatedEloquentProducts.SimplePaginate["products"]["data"]>>().toEqualTypeOf<
+            App.Models.Product[]
+        >();
+    });
+
+    test("cursorPaginate narrows products.data to App.Models.Product[]", () => {
+        expectTypeOf<NotAny<Inertia.Pages.PaginatedEloquentProducts.CursorPaginate["products"]["data"]>>().toEqualTypeOf<
+            App.Models.Product[]
+        >();
+    });
+});

--- a/workbench/app/Http/Controllers/PaginatedEloquentProductController.php
+++ b/workbench/app/Http/Controllers/PaginatedEloquentProductController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PaginatedEloquentProductController
+{
+    public function paginate(): Response
+    {
+        return Inertia::render('PaginatedEloquentProducts/Paginate', [
+            'products' => Product::paginate(5),
+        ]);
+    }
+
+    public function simplePaginate(): Response
+    {
+        return Inertia::render('PaginatedEloquentProducts/SimplePaginate', [
+            'products' => Product::simplePaginate(5),
+        ]);
+    }
+
+    public function cursorPaginate(): Response
+    {
+        return Inertia::render('PaginatedEloquentProducts/CursorPaginate', [
+            'products' => Product::cursorPaginate(5),
+        ]);
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\NamedInvokableController;
 use App\Http\Controllers\NavigationItemController;
 use App\Http\Controllers\Nested\NestedController;
 use App\Http\Controllers\OptionalController;
+use App\Http\Controllers\PaginatedEloquentProductController;
 use App\Http\Controllers\ParameterNameController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\Prism\Prism\PrismController as NestedPrismController;
@@ -49,6 +50,10 @@ Route::delete('/posts/{post}', [PostController::class, 'destroy'])->name('posts.
 
 Route::get('/eloquent-products', [EloquentProductController::class, 'index'])->name('eloquent-products.index');
 Route::get('/eloquent-products/{product}', [EloquentProductController::class, 'show'])->name('eloquent-products.show');
+
+Route::get('/paginated-eloquent-products/paginate', [PaginatedEloquentProductController::class, 'paginate'])->name('paginated-eloquent-products.paginate');
+Route::get('/paginated-eloquent-products/simple-paginate', [PaginatedEloquentProductController::class, 'simplePaginate'])->name('paginated-eloquent-products.simple-paginate');
+Route::get('/paginated-eloquent-products/cursor-paginate', [PaginatedEloquentProductController::class, 'cursorPaginate'])->name('paginated-eloquent-products.cursor-paginate');
 
 Route::get('/date-time', [DateTimeController::class, 'show'])->name('date-time.show');
 


### PR DESCRIPTION
## summary

when a controller returns `Product::paginate(5)` as an Inertia response prop to the frontend, wayfinder previously had no way to carry the model type through the paginator, so the typegen emitted `data: Record<string, unknown>` instead of `data: App.Models.Product[]`. once three upstream PRs (https://github.com/laravel/framework/pull/60045 + https://github.com/laravel/surveyor/pull/39 + https://github.com/laravel/ranger/pull/34) are merged, the full pipeline works automatically.

this change adds end-to-end test coverage confirming it.

## related

- https://github.com/laravel/framework/pull/60045
- https://github.com/laravel/framework/pull/60052
- https://github.com/laravel/surveyor/pull/39
- https://github.com/laravel/ranger/pull/34

## merge order
`laravel/framework` -> `laravel/surveyor` -> `laravel/ranger` -> `this`