### PR TITLE
Respect Eloquent's $hidden, $visible, $appends in generated model types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/filesystem": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ranger": "^0.2.2",
+        "laravel/ranger": "^0.2.4",
         "laravel/surveyor": "^0.2.1",
         "phpstan/phpdoc-parser": "^2.3"
     },

--- a/src/Converters/Models.php
+++ b/src/Converters/Models.php
@@ -10,7 +10,7 @@ class Models extends Converter
 {
     public function convert(Model $model): null
     {
-        $properties = array_merge($model->getAttributes(), $model->getRelations());
+        $properties = $model->visibleProperties();
 
         if ($model->snakeCaseAttributes()) {
             $properties = collect($properties)->mapWithKeys(

--- a/tests/Models.test.ts
+++ b/tests/Models.test.ts
@@ -19,6 +19,17 @@ describe("Models", () => {
         expect(content).toContain("export type User");
     });
 
+    test("User type omits attributes listed in $hidden", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        const userType = content
+            .split("export type User")[1]
+            ?.split("export type")[0];
+
+        expect(userType).toBeDefined();
+        expect(userType).not.toMatch(/\bpassword\b/);
+        expect(userType).not.toMatch(/\bremember_token\b/);
+    });
+
     test.skip("User model types directory exists", () => {
         const userTypesPath = join(
             __dirname,


### PR DESCRIPTION
Routes model type generation through Ranger's new visibleProperties() helper instead of merging attributes and relations manually, so attributes hidden from serialization (e.g. password, remember_token) no longer appear in the generated TypeScript types. Same goes for the $visible whitelist when defined.

Requires the matching Ranger release; composer constraint will need a bump before this merges.

Closes #135
