### PR TITLE
Clarify behavior when multiple routes share an action

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,33 @@ import { show } from "@/routes/post";
 show(1); // { url: "/posts/1", method: "get" }
 ```
 
+### Multiple Routes To The Same Action
+
+If two or more routes point at the same controller method, Wayfinder can't tell which URL you meant from the action alone, so the generated export becomes a dictionary keyed by URI instead of a callable:
+
+```php
+Route::get('clients/{client}/payments', [ClientPaymentsController::class, 'index'])
+    ->name('clients.payments.index');
+
+Route::get('clients/{client}/payments-archive', [ClientPaymentsController::class, 'index'])
+    ->name('clients.payments.archive');
+```
+
+```ts
+import { index } from "@/actions/App/Http/Controllers/ClientPaymentsController";
+
+// `index` is not callable directly — pick the URI you want:
+index["/clients/{client}/payments"]({ client: 1 });
+```
+
+In most cases it is easier to import the route by name from your generated `routes/` directory instead:
+
+```ts
+import { index } from "@/routes/clients/payments";
+
+index({ client: 1 }); // { url: "/clients/1/payments", method: "get" }
+```
+
 ### Conventional Forms
 
 If your application uses conventional HTML form submissions, Wayfinder can help you out there as well. First, opt into form variants when generating your TypeScript definitions:

--- a/resources/multi-method.blade.ts
+++ b/resources/multi-method.blade.ts
@@ -7,6 +7,11 @@
     ])
 @endforeach
 
+/**
+* Multiple routes resolve to {!! $controller !!}::{!! $original_method !!}, so this export is a
+* dictionary keyed by URI rather than a callable. Call a specific route with `{!! $method !!}['<uri>'](...)`,
+* or import the route by name from your generated `routes/` directory.
+*/
 {!! when($shouldExport, 'export ') !!}const {!! $method !!} = {
 @foreach ($routes as $route)
     {!! $route['uri'] !!}: {!! $route['tempMethod'] !!},


### PR DESCRIPTION
When two routes point at the same controller method, the generated action becomes a URI-keyed dictionary rather than a callable, which produces a confusing "is not a function" error at the call site.

Adds a JSDoc comment above the generated dictionary explaining the shape and pointing at the named-route alternative, plus a short README section covering the same ground.

Closes #98
