### PR TITLE
next: Bump happy-dom minimum to 20.8.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "@inertiajs/core": "^3.1.0",
         "@types/node": "^22.7.5",
         "eslint": "^9.29.0",
-        "happy-dom": ">=20.0.2",
+        "happy-dom": ">=20.8.9",
         "typescript-eslint": "^8.34.1",
         "vite": "^7.1.3",
         "vitest": "^3.2.3"


### PR DESCRIPTION
Bumps the floor of the happy-dom dev dependency to pull in the recent security fix.
