### PR TITLE
Fix TypeScript type object shorthand bug for properties named 'number'

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/src/Langs/TypeScript/ObjectKeyValueBuilder.php
+++ b/src/Langs/TypeScript/ObjectKeyValueBuilder.php
@@ -77,6 +77,7 @@ class ObjectKeyValueBuilder implements Stringable
 
     public function __toString(): string
     {
+        $value = $this->value;
         $block = $this->meta();
 
         if ($block !== '') {
@@ -89,22 +90,22 @@ class ObjectKeyValueBuilder implements Stringable
             $key = "...{$key}";
         }
 
-        if ($this->value !== null) {
-            $value = $this->quote ? TypeScript::quote($this->value) : $this->value;
+        $block .= $key;
+
+        if ($value === null) {
+            return $block;
         }
 
-        if ($this->value === null) {
-            return $block.$key;
-        }
+        $value = $this->quote ? TypeScript::quote($value) : $value;
 
         if ($this->shorthand && ! $this->optional && ! str_contains($key, '"') && $key === $value) {
-            return $block.$key;
+            return $block;
         }
 
         if ($this->optional) {
-            return $block.$key.'?: '.$value;
+            return $block.'?: '.$value;
         }
 
-        return $block.$key.': '.$value;
+        return $block.': '.$value;
     }
 }

--- a/src/Langs/TypeScript/ObjectKeyValueBuilder.php
+++ b/src/Langs/TypeScript/ObjectKeyValueBuilder.php
@@ -20,6 +20,8 @@ class ObjectKeyValueBuilder implements Stringable
 
     protected bool $spread = false;
 
+    protected bool $shorthand = true;
+
     public function __construct(protected string $key)
     {
         //
@@ -66,6 +68,13 @@ class ObjectKeyValueBuilder implements Stringable
         return $this;
     }
 
+    public function shorthand(bool $shorthand = true): static
+    {
+        $this->shorthand = $shorthand;
+
+        return $this;
+    }
+
     public function __toString(): string
     {
         $block = $this->meta();
@@ -88,7 +97,7 @@ class ObjectKeyValueBuilder implements Stringable
             return $block.$key;
         }
 
-        if (! $this->optional && ! str_contains($key, '"') && $key === $value) {
+        if ($this->shorthand && ! $this->optional && ! str_contains($key, '"') && $key === $value) {
             return $block.$key;
         }
 

--- a/src/Langs/TypeScript/TypeObjectBuilder.php
+++ b/src/Langs/TypeScript/TypeObjectBuilder.php
@@ -23,6 +23,7 @@ class TypeObjectBuilder implements Stringable
     public function key(string $key): ObjectKeyValueBuilder
     {
         $keyValue = new ObjectKeyValueBuilder($key);
+        $keyValue->shorthand(false);
 
         $this->keyValuePairs[] = $keyValue;
 

--- a/tests/Unit/Langs/TypeScript/TypeObjectBuilderTest.php
+++ b/tests/Unit/Langs/TypeScript/TypeObjectBuilderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Langs\TypeScript;
+
+use Laravel\Wayfinder\Langs\TypeScript;
+use PHPUnit\Framework\TestCase;
+
+class TypeObjectBuilderTest extends TestCase
+{
+    public function test_type_object_does_not_use_shorthand_for_matching_key_and_value(): void
+    {
+        $type = TypeScript::objectToTypeObject([
+            'number' => 'number',
+        ], false);
+
+        $this->assertSame('{ number: number }', (string) $type);
+    }
+
+    public function test_object_record_uses_shorthand_for_matching_key_and_value(): void
+    {
+        $object = TypeScript::objectToRecord([
+            'url' => 'url',
+        ], false);
+
+        $this->assertStringContainsString('url', (string) $object);
+        $this->assertStringNotContainsString('url: url', (string) $object);
+    }
+}


### PR DESCRIPTION
## Summary

Wayfinder can emit invalid TypeScript when a model has a real domain property named `number`.

For example, `App\Models\Quarter` with a persisted `number` field generates:

```ts
type Quarter = {
    id: number;
    year: number;
    number;   // <-- invalid shorthand in a type literal
};
```

This syntax is valid in JavaScript object literals, but invalid in TypeScript type literals where a type member must include a type annotation.

## Root Cause

`ObjectKeyValueBuilder::__toString()` collapses key-value pairs to shorthand when `$key === $value`. This is correct for JavaScript object literals (`{ url }`) but `TypeObjectBuilder` reuses the same builder for TypeScript type members, where `number` as the key and `number` as the primitive type are different constructs.

## Fix

- Made shorthand emission configurable on `ObjectKeyValueBuilder` via a new `shorthand(bool)` method.
- Disabled shorthand for `TypeObjectBuilder` so type members always emit explicit `key: value` pairs.
- Preserved existing shorthand behavior for JavaScript object literals (`ObjectBuilder`).

## Tests

Added unit tests covering both behaviors:

- `TypeObjectBuilderTest::test_type_object_does_not_use_shorthand_for_matching_key_and_value`
- `TypeObjectBuilderTest::test_object_record_uses_shorthand_for_matching_key_and_value`