### PR TITLE
[next] perf(tests): run `GenerateCommandTest` in-process via Testbench

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -59,6 +59,10 @@ class GenerateCommand extends Command
         Enums $enumConverter,
         Routes $routesConverter,
     ) {
+        TypeScript::reset();
+        $this->results = [];
+        $this->ranger = app(Ranger::class);
+
         AnalyzedCache::setCacheDirectory($this->config->get('wayfinder.cache.directory'));
 
         if ($this->option('fresh') || ! $this->config->get('wayfinder.cache.enabled')) {

--- a/src/Langs/TypeScript.php
+++ b/src/Langs/TypeScript.php
@@ -20,6 +20,12 @@ class TypeScript
 
     protected static $safeImports = [];
 
+    public static function reset(): void
+    {
+        static::$namespaced = [];
+        static::$safeImports = [];
+    }
+
     public const RESERVED_KEYWORDS = [
         'break',
         'case',

--- a/src/Registry/ConverterRegistry.php
+++ b/src/Registry/ConverterRegistry.php
@@ -11,14 +11,14 @@ class ConverterRegistry
 
     public function register(string $converter): void
     {
+        if ($this->hasConverter($converter)) {
+            return;
+        }
+
         $instance = app($converter);
 
         if (! ($instance instanceof ConverterInterface)) {
             throw new InvalidArgumentException("Converter {$converter} must implement ".ConverterInterface::class);
-        }
-
-        if ($this->hasConverter($converter)) {
-            throw new InvalidArgumentException("Converter {$converter} already registered");
         }
 
         $this->converters[$converter] = $instance;

--- a/tests/Feature/GenerateCommandTest.php
+++ b/tests/Feature/GenerateCommandTest.php
@@ -3,33 +3,37 @@
 namespace Tests\Feature;
 
 use Illuminate\Filesystem\Filesystem;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\Process;
+use Laravel\Ranger\RangerServiceProvider;
+use Laravel\Surveyor\SurveyorServiceProvider;
+use Laravel\Wayfinder\WayfinderServiceProvider;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
 
 use function Illuminate\Filesystem\join_paths;
 
 class GenerateCommandTest extends TestCase
 {
+    use WithWorkbench;
+
     private string $tempPath;
 
     private Filesystem $files;
 
-    private string $rootPath;
+    protected function getPackageProviders($app): array
+    {
+        return [
+            RangerServiceProvider::class,
+            SurveyorServiceProvider::class,
+            WayfinderServiceProvider::class,
+        ];
+    }
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->files = new Filesystem;
-        $this->rootPath = realpath(join_paths(__DIR__, '..', '..'));
         $this->tempPath = join_paths(sys_get_temp_dir(), 'wayfinder-prune-'.uniqid());
-
-        $envExample = join_paths($this->rootPath, 'workbench', '.env.example');
-        $envFile = join_paths($this->rootPath, 'workbench', '.env');
-
-        if ($this->files->exists($envExample) && ! $this->files->exists($envFile)) {
-            $this->files->copy($envExample, $envFile);
-        }
     }
 
     protected function tearDown(): void
@@ -41,22 +45,13 @@ class GenerateCommandTest extends TestCase
 
     private function generate(): void
     {
-        $process = new Process([
-            join_paths($this->rootPath, 'vendor', 'bin', 'testbench'),
-            'wayfinder:generate',
-            '--path='.$this->tempPath,
-            '--app-path='.join_paths($this->rootPath, 'workbench', 'app'),
-            '--base-path='.join_paths($this->rootPath, 'workbench'),
-            '--fresh',
-        ], $this->rootPath);
+        $rootPath = realpath(join_paths(__DIR__, '..', '..'));
 
-        $process->setTimeout(60);
-        $process->run();
-
-        $this->assertTrue(
-            $process->isSuccessful(),
-            'wayfinder:generate failed: '.$process->getErrorOutput().$process->getOutput()
-        );
+        $this->artisan('wayfinder:generate', [
+            '--path' => $this->tempPath,
+            '--app-path' => join_paths($rootPath, 'workbench', 'app'),
+            '--base-path' => join_paths($rootPath, 'workbench'),
+        ])->assertSuccessful();
     }
 
     public function test_generated_files_exist_after_generate(): void


### PR DESCRIPTION
## summary

`GenerateCommandTest` currently runs `wayfinder:generate` by spawning a testbench subprocess for each test method. each subprocess pays the full cost of bootstrapping a new php process and laravel application from scratch, adding up to ~85s for the full suite with no caching benefit between tests.

this change replaces subprocesses with `$this->artisan()` (via  testbench's `WithWorkbench`) running the command in-process. this eliminates per-test process spawn overhead and allows the AnalyzedCache disk cache to warm across tests (and across runs), since the cache is no longer discarded with each subprocess exit.

three supporting changes were required to make in-process execution safe across multiple test method calls within the same php process:

- `TypeScript::reset()` - clears the static `$namespaced` and `$safeImports` properties between command invocations, preventing state from one test bleeding into the next
- `GenerateCommand::handle()` - explicitly resets `$this->results` and re-resolves `$this->ranger` at the top of each invocation for the same reason
- `ConverterRegistry::register()` - made idempotent (silently skips already-registered converters) since service providers register converters once at boot, and the same process may invoke the command multiple times

## `vendor/bin/phpunit` run length before / after

#### `next` branch (subprocess per test, no cross-test caching)
- ~85s per run, repeated consistently

#### this branch (in-process, AnalyzedCache warms across tests)
- ~12s first run (cold disk cache)
- ~4s subsequent runs (warm disk cache)

the ~12s first run reflects the AnalyzedCache rebuilding its disk cache (typically after a git checkout updates file mtimes). subsequent runs hit the warm cache and drop to ~4s.
