### PR TITLE
[next] Add 'boost.*' to ignored route names in wayfinder

### DIFF
--- a/config/wayfinder.php
+++ b/config/wayfinder.php
@@ -10,7 +10,7 @@ return [
                 // Patterns to ignore for URLs (e.g. 'nova-api/*')
                 'urls' => [],
                 // Patterns to ignore for route names (e.g. 'nova.*')
-                'names' => ['nova.*'],
+                'names' => ['boost.*', 'nova.*'],
             ],
         ],
         'models' => env('WAYFINDER_GENERATE_MODELS', true),


### PR DESCRIPTION
This pull request adds boost.* to the default list of ignored route names within Wayfinder, as the Laravel Boost toggle is on by default on new Laravel app creation.