### PR TITLE
[next] experiment: port tests to pest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "require-dev": {
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/pint": "^1.21",
-        "orchestra/testbench": "^10.1|^11.0"
+        "orchestra/testbench": "^10.1|^11.0",
+        "pestphp/pest": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -47,7 +48,10 @@
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
     "type": "module",
     "scripts": {
-        "test": "vendor/bin/pest && vitest run && npm run lint && npm run test-routes-cached && npm run lint && npm run test-inertia-component && npm run lint && npm run tsc && npm run tsc:wayfinder",
-        "test-routes-cached": "WAYFINDER_CACHE_ROUTES=1 vitest run",
-        "test-inertia-component": "WAYFINDER_GENERATE_INERTIA_COMPONENT=1 vitest run",
+        "test": "run-s test:php test:ts test:ts:cached test:ts:inertia test:types",
+        "test:php": "vendor/bin/pest",
+        "test:ts": "run-s test:vitest lint",
+        "test:ts:cached": "run-s test:vitest:cached lint",
+        "test:ts:inertia": "run-s test:vitest:inertia lint",
+        "test:vitest": "vitest run",
+        "test:vitest:cached": "WAYFINDER_CACHE_ROUTES=1 vitest run",
+        "test:vitest:inertia": "WAYFINDER_GENERATE_INERTIA_COMPONENT=1 vitest run",
+        "test:types": "run-s tsc tsc:wayfinder",
         "lint": "eslint ./workbench/resources/js --ext .ts,.tsx",
         "lint:fix": "eslint ./workbench/resources/js --ext .ts,.tsx --fix",
         "format": "npx --yes prettier --write \"resources/js/**/*.{ts,js,json}\"",
@@ -16,6 +22,7 @@
         "@types/node": "^22.7.5",
         "eslint": "^9.29.0",
         "happy-dom": ">=20.8.9",
+        "npm-run-all2": "^8.0.4",
         "typescript-eslint": "^8.34.1",
         "vite": "^7.1.3",
         "vitest": "^3.2.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "type": "module",
     "scripts": {
-        "test": "vendor/bin/phpunit && vitest run && npm run lint && npm run test-routes-cached && npm run lint && npm run test-inertia-component && npm run lint && npm run tsc && npm run tsc:wayfinder",
+        "test": "vendor/bin/pest && vitest run && npm run lint && npm run test-routes-cached && npm run lint && npm run test-inertia-component && npm run lint && npm run tsc && npm run tsc:wayfinder",
         "test-routes-cached": "WAYFINDER_CACHE_ROUTES=1 vitest run",
         "test-inertia-component": "WAYFINDER_GENERATE_INERTIA_COMPONENT=1 vitest run",
         "lint": "eslint ./workbench/resources/js --ext .ts,.tsx",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+shamefullyHoist: true
+allowBuilds:
+  esbuild: true

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -59,6 +59,10 @@ class GenerateCommand extends Command
         Enums $enumConverter,
         Routes $routesConverter,
     ) {
+        TypeScript::reset();
+        $this->results = [];
+        $this->ranger = app(Ranger::class);
+
         AnalyzedCache::setCacheDirectory($this->config->get('wayfinder.cache.directory'));
 
         if ($this->option('fresh') || ! $this->config->get('wayfinder.cache.enabled')) {

--- a/src/Langs/TypeScript.php
+++ b/src/Langs/TypeScript.php
@@ -20,6 +20,12 @@ class TypeScript
 
     protected static $safeImports = [];
 
+    public static function reset(): void
+    {
+        static::$namespaced = [];
+        static::$safeImports = [];
+    }
+
     public const RESERVED_KEYWORDS = [
         'break',
         'case',

--- a/src/Registry/ConverterRegistry.php
+++ b/src/Registry/ConverterRegistry.php
@@ -11,14 +11,14 @@ class ConverterRegistry
 
     public function register(string $converter): void
     {
+        if ($this->hasConverter($converter)) {
+            return;
+        }
+
         $instance = app($converter);
 
         if (! ($instance instanceof ConverterInterface)) {
             throw new InvalidArgumentException("Converter {$converter} must implement ".ConverterInterface::class);
-        }
-
-        if ($this->hasConverter($converter)) {
-            throw new InvalidArgumentException("Converter {$converter} already registered");
         }
 
         $this->converters[$converter] = $instance;

--- a/tests/Feature/GenerateCommandTest.php
+++ b/tests/Feature/GenerateCommandTest.php
@@ -1,167 +1,124 @@
 <?php
 
-namespace Tests\Feature;
-
 use Illuminate\Filesystem\Filesystem;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\Process;
 
 use function Illuminate\Filesystem\join_paths;
 
-class GenerateCommandTest extends TestCase
+beforeEach(function () {
+    $this->files = new Filesystem;
+    $this->tempPath = join_paths(sys_get_temp_dir(), 'wayfinder-prune-'.uniqid());
+});
+
+afterEach(function () {
+    $this->files->deleteDirectory($this->tempPath);
+});
+
+function generate(object $test): void
 {
-    private string $tempPath;
+    $rootPath = realpath(join_paths(__DIR__, '..', '..'));
 
-    private Filesystem $files;
-
-    private string $rootPath;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->files = new Filesystem;
-        $this->rootPath = realpath(join_paths(__DIR__, '..', '..'));
-        $this->tempPath = join_paths(sys_get_temp_dir(), 'wayfinder-prune-'.uniqid());
-
-        $envExample = join_paths($this->rootPath, 'workbench', '.env.example');
-        $envFile = join_paths($this->rootPath, 'workbench', '.env');
-
-        if ($this->files->exists($envExample) && ! $this->files->exists($envFile)) {
-            $this->files->copy($envExample, $envFile);
-        }
-    }
-
-    protected function tearDown(): void
-    {
-        $this->files->deleteDirectory($this->tempPath);
-
-        parent::tearDown();
-    }
-
-    private function generate(): void
-    {
-        $process = new Process([
-            join_paths($this->rootPath, 'vendor', 'bin', 'testbench'),
-            'wayfinder:generate',
-            '--path='.$this->tempPath,
-            '--app-path='.join_paths($this->rootPath, 'workbench', 'app'),
-            '--base-path='.join_paths($this->rootPath, 'workbench'),
-            '--fresh',
-        ], $this->rootPath);
-
-        $process->setTimeout(60);
-        $process->run();
-
-        $this->assertTrue(
-            $process->isSuccessful(),
-            'wayfinder:generate failed: '.$process->getErrorOutput().$process->getOutput()
-        );
-    }
-
-    public function test_generated_files_exist_after_generate(): void
-    {
-        $this->generate();
-
-        $this->assertDirectoryExists($this->tempPath);
-        $this->assertFileExists(join_paths($this->tempPath, 'index.ts'));
-        $this->assertNotEmpty($this->files->allFiles($this->tempPath));
-    }
-
-    public function test_stale_files_are_removed_while_current_files_are_kept(): void
-    {
-        $this->generate();
-
-        $current = collect($this->files->allFiles($this->tempPath))
-            ->map(fn ($file) => $file->getPathname());
-
-        $this->assertNotEmpty($current);
-
-        $stale = join_paths($this->tempPath, 'definitely-not-a-real-route.ts');
-        $this->files->put($stale, '// stale');
-        $this->assertFileExists($stale);
-
-        $this->generate();
-
-        $this->assertFileDoesNotExist($stale);
-        $current->each(fn ($path) => $this->assertFileExists($path));
-    }
-
-    public function test_empty_directories_are_pruned(): void
-    {
-        $this->generate();
-
-        $orphanDir = join_paths($this->tempPath, 'orphan-dir');
-        $this->files->ensureDirectoryExists($orphanDir);
-        $this->files->put(join_paths($orphanDir, 'thing.ts'), '// stale');
-
-        $this->generate();
-
-        $this->assertDirectoryDoesNotExist($orphanDir);
-    }
-
-    public function test_helper_index_is_skipped_when_contents_match(): void
-    {
-        $this->generate();
-
-        $destination = join_paths($this->tempPath, 'index.ts');
-        $beforeMtime = filemtime($destination);
-
-        clearstatcache(true, $destination);
-        sleep(1);
-
-        $this->generate();
-
-        clearstatcache(true, $destination);
-        $this->assertSame($beforeMtime, filemtime($destination));
-    }
-
-    public function test_unchanged_generated_files_are_not_rewritten(): void
-    {
-        $this->generate();
-
-        $sample = collect($this->files->allFiles($this->tempPath))
-            ->map(fn ($file) => $file->getPathname())
-            ->first(fn ($path) => str_ends_with($path, '.ts') && ! str_ends_with($path, 'index.ts'));
-
-        $this->assertNotNull($sample, 'expected at least one non-index generated file');
-
-        $beforeMtime = filemtime($sample);
-
-        clearstatcache(true, $sample);
-        sleep(1);
-
-        $this->generate();
-
-        clearstatcache(true, $sample);
-        $this->assertSame($beforeMtime, filemtime($sample));
-    }
-
-    public function test_noop_regenerate_does_not_touch_any_file(): void
-    {
-        $this->generate();
-
-        $before = collect($this->files->allFiles($this->tempPath))
-            ->mapWithKeys(fn ($file) => [$file->getPathname() => filemtime($file->getPathname())]);
-
-        $this->assertNotEmpty($before);
-
-        clearstatcache();
-        sleep(1);
-
-        $this->generate();
-
-        clearstatcache();
-        $after = collect($this->files->allFiles($this->tempPath))
-            ->mapWithKeys(fn ($file) => [$file->getPathname() => filemtime($file->getPathname())]);
-
-        $this->assertSame($before->keys()->sort()->values()->all(), $after->keys()->sort()->values()->all());
-
-        $changed = $before->filter(fn ($mtime, $path) => $after->get($path) !== $mtime);
-
-        $this->assertEmpty(
-            $changed,
-            'expected no files to be rewritten on a no-op regen, got: '.$changed->keys()->implode(', ')
-        );
-    }
+    $test->artisan('wayfinder:generate', [
+        '--path' => $test->tempPath,
+        '--app-path' => join_paths($rootPath, 'workbench', 'app'),
+        '--base-path' => join_paths($rootPath, 'workbench'),
+    ])->assertSuccessful();
 }
+
+test('generated files exist after generate', function () {
+    generate($this);
+
+    expect($this->tempPath)->toBeDirectory();
+    expect(join_paths($this->tempPath, 'index.ts'))->toBeFile();
+    expect($this->files->allFiles($this->tempPath))->not->toBeEmpty();
+});
+
+test('stale files are removed while current files are kept', function () {
+    generate($this);
+
+    $current = collect($this->files->allFiles($this->tempPath))
+        ->map(fn ($file) => $file->getPathname());
+
+    expect($current)->not->toBeEmpty();
+
+    $stale = join_paths($this->tempPath, 'definitely-not-a-real-route.ts');
+    $this->files->put($stale, '// stale');
+    expect($stale)->toBeFile();
+
+    generate($this);
+
+    expect($stale)->not->toBeFile();
+    $current->each(fn ($path) => expect($path)->toBeFile());
+});
+
+test('empty directories are pruned', function () {
+    generate($this);
+
+    $orphanDir = join_paths($this->tempPath, 'orphan-dir');
+    $this->files->ensureDirectoryExists($orphanDir);
+    $this->files->put(join_paths($orphanDir, 'thing.ts'), '// stale');
+
+    generate($this);
+
+    expect($orphanDir)->not->toBeDirectory();
+});
+
+test('helper index is skipped when contents match', function () {
+    generate($this);
+
+    $destination = join_paths($this->tempPath, 'index.ts');
+    $beforeMtime = filemtime($destination);
+
+    clearstatcache(true, $destination);
+    sleep(1);
+
+    generate($this);
+
+    clearstatcache(true, $destination);
+    expect(filemtime($destination))->toBe($beforeMtime);
+});
+
+test('unchanged generated files are not rewritten', function () {
+    generate($this);
+
+    $sample = collect($this->files->allFiles($this->tempPath))
+        ->map(fn ($file) => $file->getPathname())
+        ->first(fn ($path) => str_ends_with($path, '.ts') && ! str_ends_with($path, 'index.ts'));
+
+    expect($sample)->not->toBeNull();
+
+    $beforeMtime = filemtime($sample);
+
+    clearstatcache(true, $sample);
+    sleep(1);
+
+    generate($this);
+
+    clearstatcache(true, $sample);
+    expect(filemtime($sample))->toBe($beforeMtime);
+});
+
+test('noop regenerate does not touch any file', function () {
+    generate($this);
+
+    $before = collect($this->files->allFiles($this->tempPath))
+        ->mapWithKeys(fn ($file) => [$file->getPathname() => filemtime($file->getPathname())]);
+
+    expect($before)->not->toBeEmpty();
+
+    clearstatcache();
+    sleep(1);
+
+    generate($this);
+
+    clearstatcache();
+    $after = collect($this->files->allFiles($this->tempPath))
+        ->mapWithKeys(fn ($file) => [$file->getPathname() => filemtime($file->getPathname())]);
+
+    expect($before->keys()->sort()->values()->all())->toBe($after->keys()->sort()->values()->all());
+
+    $changed = $before->filter(fn ($mtime, $path) => $after->get($path) !== $mtime);
+
+    expect($changed->keys()->all())->toBeEmpty(
+        'expected no files to be rewritten on a no-op regen, got: '.$changed->keys()->implode(', ')
+    );
+});

--- a/tests/FeatureTestCase.php
+++ b/tests/FeatureTestCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests;
+
+use Laravel\Ranger\RangerServiceProvider;
+use Laravel\Surveyor\SurveyorServiceProvider;
+use Laravel\Wayfinder\WayfinderServiceProvider;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class FeatureTestCase extends TestCase
+{
+    use WithWorkbench;
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            RangerServiceProvider::class,
+            SurveyorServiceProvider::class,
+            WayfinderServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use Tests\FeatureTestCase;
+
+uses(FeatureTestCase::class)->in('Feature');

--- a/tests/Unit/Langs/TypeScript/TypeObjectBuilderTest.php
+++ b/tests/Unit/Langs/TypeScript/TypeObjectBuilderTest.php
@@ -1,28 +1,21 @@
 <?php
 
-namespace Tests\Unit\Langs\TypeScript;
-
 use Laravel\Wayfinder\Langs\TypeScript;
-use PHPUnit\Framework\TestCase;
 
-class TypeObjectBuilderTest extends TestCase
-{
-    public function test_type_object_does_not_use_shorthand_for_matching_key_and_value(): void
-    {
-        $type = TypeScript::objectToTypeObject([
-            'number' => 'number',
-        ], false);
+test('type object does not use shorthand for matching key and value', function () {
+    $type = TypeScript::objectToTypeObject([
+        'number' => 'number',
+    ], false);
 
-        $this->assertSame('{ number: number }', (string) $type);
-    }
+    expect((string) $type)->toBe('{ number: number }');
+});
 
-    public function test_object_record_uses_shorthand_for_matching_key_and_value(): void
-    {
-        $object = TypeScript::objectToRecord([
-            'url' => 'url',
-        ], false);
+test('object record uses shorthand for matching key and value', function () {
+    $object = TypeScript::objectToRecord([
+        'url' => 'url',
+    ], false);
 
-        $this->assertStringContainsString('url', (string) $object);
-        $this->assertStringNotContainsString('url: url', (string) $object);
-    }
-}
+    expect((string) $object)
+        ->toContain('url')
+        ->not->toContain('url: url');
+});


### PR DESCRIPTION
alternate version of https://github.com/laravel/wayfinder/pull/257, so same speed gains are present here (7x faster PHP test suite run from cold cache; 21x faster from warm cache)

## but why port to pest? :raised_eyebrow:

- surveyor's tests use pest
- ranger's tests use pest
- this project's frontend tests use vitest which ~rhymes with pest~ ~descended from jest~ uses the same style of tests as pest
- specs FTW

---

this change also adds a `pnpm-workspace.yaml` to enable using pnpm locally with this repo out-of-the-box. this is a non-breaking change, npm continues to work out-of-the-box as it has historically with wayfinder (verified locally with npm, and its still being used as the package manager in CI)