### PR TITLE
Add port support for base domain in Route::domain method

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -139,8 +139,10 @@ class Route
 
     public function domain(): ?string
     {
-        if ($this->base->getDomain()) {
-            return $this->base->getDomain();
+        if ($baseDomain = $this->base->getDomain()) {
+            $port = parse_url(config('app.url'), PHP_URL_PORT);
+
+            return $baseDomain.($port ? ':'.$port : '');
         }
 
         if ($this->forcedRoot) {


### PR DESCRIPTION
When we use Laravel’s domain route, it generates the URL without the port if the app URL has one.

### Example

In the `web.php` file:

```
// use the domain only, cause Laravel doesn't support port in route
Route::domain(‘myapp.com’)->group(function(){
    // routes
})
```

However, in the `.env` file:

```
APP_URL=https://myapp.com:8000
```

When we run `php artisan wayfinder:generate`, it generates the URL as follows:

```
https://myapp.com/login 
// … etc
```

but expected output should be:

```
https://myapp.com:8000/login 
// … etc
```

Therefore, for the generation of JavaScript routes and actions, this support will add the port to the URL generation time.