### PR TITLE
Fix reserved TypeScript identifiers in generated method names

### DIFF
--- a/src/Langs/TypeScript.php
+++ b/src/Langs/TypeScript.php
@@ -21,6 +21,7 @@ class TypeScript
     protected static $safeImports = [];
 
     public const RESERVED_KEYWORDS = [
+        'await',
         'break',
         'case',
         'catch',
@@ -32,6 +33,7 @@ class TypeScript
         'delete',
         'do',
         'else',
+        'enum',
         'export',
         'extends',
         'false',
@@ -39,12 +41,20 @@ class TypeScript
         'for',
         'function',
         'if',
+        'implements',
         'import',
         'in',
         'instanceof',
+        'interface',
+        'let',
         'new',
         'null',
+        'package',
+        'private',
+        'protected',
+        'public',
         'return',
+        'static',
         'super',
         'switch',
         'this',
@@ -56,6 +66,7 @@ class TypeScript
         'void',
         'while',
         'with',
+        'yield',
     ];
 
     public static function literalUnion(string $type, array|Collection $values): VariableBuilder

--- a/tests/DisallowedMethodNames.test.ts
+++ b/tests/DisallowedMethodNames.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import DisallowedMethodNameController, {
     deleteMethod,
+    interfaceMethod,
     method404,
 } from "../workbench/resources/js/wayfinder/App/Http/Controllers/DisallowedMethodNameController";
 import method2fa from "../workbench/resources/js/wayfinder/routes/2fa";
@@ -10,14 +11,19 @@ import disallowed from "../workbench/resources/js/wayfinder/routes/disallowed";
 test("will append `method` to invalid methods", () => {
     expect(method404.url()).toBe("/disallowed/404");
     expect(deleteMethod.url()).toBe("/disallowed/delete");
+    expect(interfaceMethod.url()).toBe("/disallowed/interface");
     expect(DisallowedMethodNameController.delete.url()).toBe(
         "/disallowed/delete"
+    );
+    expect(DisallowedMethodNameController.interface.url()).toBe(
+        "/disallowed/interface"
     );
     expect(DisallowedMethodNameController[404].url()).toBe("/disallowed/404");
 });
 
 test("will append `method` to invalid methods", () => {
     expect(disallowed[404].url()).toBe("/disallowed/404");
+    expect(disallowed.interface.url()).toBe("/disallowed/interface");
 });
 
 test("will properly handle leading numbers", () => {

--- a/tests/Unit/Langs/TypeScript/SafeMethodTest.php
+++ b/tests/Unit/Langs/TypeScript/SafeMethodTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\Langs\TypeScript;
+
+use Laravel\Wayfinder\Langs\TypeScript;
+use PHPUnit\Framework\TestCase;
+
+class SafeMethodTest extends TestCase
+{
+    public function test_reserved_keywords_are_suffixed(): void
+    {
+        $keywords = [
+            'await',
+            'enum',
+            'implements',
+            'interface',
+            'let',
+            'package',
+            'private',
+            'protected',
+            'public',
+            'static',
+            'yield',
+        ];
+
+        foreach ($keywords as $keyword) {
+            $this->assertSame(
+                $keyword.'Method',
+                TypeScript::safeMethod($keyword, 'Method'),
+                "Expected [{$keyword}] to be suffixed.",
+            );
+        }
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -94,6 +94,7 @@ Route::get('/disallowed/delete', [DisallowedMethodNameController::class, 'delete
 Route::get('/disallowed/404', [DisallowedMethodNameController::class, '404'])->name('disallowed.404');
 Route::get('/disallowed/2fa', [DisallowedMethodNameController::class, '2fa'])->name('2fa.disallowed');
 Route::get('/disallowed/default', [DisallowedMethodNameController::class, 'default'])->name('default.login');
+Route::get('/disallowed/interface', [DisallowedMethodNameController::class, 'interface'])->name('disallowed.interface');
 Route::get('/navigation-items/{item}/options', [NavigationItemController::class, 'options']);
 
 Route::get('/anonymous-middleware', [AnonymousMiddlewareController::class, 'show']);


### PR DESCRIPTION
## Summary

This restores the full reserved TypeScript / JavaScript keyword list used when generating safe method names.

Without this, routes or controller methods named with keywords such as `interface`, `enum`, `await`, or `let` can generate invalid TypeScript exports/imports on `next`.

## Changes

- Add missing reserved keywords back to `TypeScript::RESERVED_KEYWORDS`
- Add a workbench route named `disallowed.interface`
- Add regression coverage for generated `interfaceMethod`
- Add a unit test for the missing reserved keywords

## Tests

- `composer format`
- `vendor/bin/phpunit tests/Unit/Langs/TypeScript`
- `npx vitest run tests/DisallowedMethodNames.test.ts`
- `npm run tsc`
- `npm run tsc:wayfinder`
- `npm test`