### PR TITLE
Add typed route request and response contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,32 @@ PostController.index.head();
 PostController.update.patch({ post: 1 });
 ```
 
+### Route Type Helpers
+
+Generated route functions carry their request and response contracts, so client helpers can infer the TypeScript types that Wayfinder generated for the matching controller method:
+
+```typescript
+import { show } from "@/wayfinder/App/Http/Controllers/ProductController";
+import type { RequestOf, ResponseOf } from "@/wayfinder";
+
+type ShowProductRequest = RequestOf<typeof show>;
+type ShowProductResponse = ResponseOf<typeof show>;
+```
+
+This is useful when building typed HTTP clients around Wayfinder routes:
+
+```typescript
+async function api<TRoute extends { url: string }>(
+    route: TRoute,
+): Promise<ResponseOf<TRoute>> {
+    const response = await fetch(route.url);
+
+    return response.json();
+}
+
+const product = await api(show({ product: 1 }));
+```
+
 ### Form-Safe Routes
 
 HTML forms only support GET and POST methods. Wayfinder provides `.form` variants that automatically add Laravel's `_method` field for method spoofing:

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -13,29 +13,71 @@ type Method = "get" | "post" | "put" | "delete" | "patch" | "head" | "options";
 type ParamValue = string | number | boolean;
 type UrlDefaults = Record<string, unknown>;
 
+type RouteContractKey = "__wayfinderRouteContract";
+
+export type RouteContract<TRequest = unknown, TResponse = unknown> = {
+    readonly __wayfinderRouteContract?: {
+        request: TRequest;
+        response: TResponse;
+    };
+};
+
 let urlDefaults: () => UrlDefaults = () => ({});
 
 export type RouteDefinition<
     TMethod extends Method | Method[],
     TComponent extends string | Record<string, string> | undefined = undefined,
+    TRequest = unknown,
+    TResponse = unknown,
 > = {
     url: string;
     component?: TComponent;
-} & (TMethod extends Method[] ? { methods: TMethod } : { method: TMethod });
+} & RouteContract<TRequest, TResponse> &
+    (TMethod extends Method[] ? { methods: TMethod } : { method: TMethod });
 
 export type RouteFormDefinition<
     TMethod extends Method,
     TComponent extends string | Record<string, string> | undefined = undefined,
+    TRequest = unknown,
+    TResponse = unknown,
 > = {
     action: string;
     method: TMethod;
     component?: TComponent;
-};
+} & RouteContract<TRequest, TResponse>;
 
 export type RouteQueryOptions = {
     query?: QueryParams;
     mergeQuery?: QueryParams;
 };
+
+type RouteContractOf<T> =
+    T extends (...args: infer TArguments) => infer TReturn
+        ? TArguments extends unknown[]
+            ? RouteContractOf<TReturn>
+            : never
+        : RouteContractKey extends keyof T
+          ? T extends RouteContract<infer TRequest, infer TResponse>
+              ? {
+                    request: TRequest;
+                    response: TResponse;
+                }
+              : never
+          : never;
+
+export type RequestOf<T> =
+    [RouteContractOf<T>] extends [never]
+        ? never
+        : RouteContractOf<T> extends { request: infer TRequest }
+          ? TRequest
+          : never;
+
+export type ResponseOf<T> =
+    [RouteContractOf<T>] extends [never]
+        ? never
+        : RouteContractOf<T> extends { response: infer TResponse }
+          ? TResponse
+          : never;
 
 export const formSafeOptions = (
     method: Method,

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -51,33 +51,30 @@ export type RouteQueryOptions = {
     mergeQuery?: QueryParams;
 };
 
-type RouteContractOf<T> =
-    T extends (...args: infer TArguments) => infer TReturn
-        ? TArguments extends unknown[]
-            ? RouteContractOf<TReturn>
-            : never
-        : RouteContractKey extends keyof T
-          ? T extends RouteContract<infer TRequest, infer TResponse>
-              ? {
-                    request: TRequest;
-                    response: TResponse;
-                }
-              : never
-          : never;
+type RouteContractOf<T> = T extends (...args: infer TArguments) => infer TReturn
+    ? TArguments extends unknown[]
+        ? RouteContractOf<TReturn>
+        : never
+    : RouteContractKey extends keyof T
+      ? T extends RouteContract<infer TRequest, infer TResponse>
+          ? {
+                request: TRequest;
+                response: TResponse;
+            }
+          : never
+      : never;
 
-export type RequestOf<T> =
-    [RouteContractOf<T>] extends [never]
-        ? never
-        : RouteContractOf<T> extends { request: infer TRequest }
-          ? TRequest
-          : never;
+export type RequestOf<T> = [RouteContractOf<T>] extends [never]
+    ? never
+    : RouteContractOf<T> extends { request: infer TRequest }
+      ? TRequest
+      : never;
 
-export type ResponseOf<T> =
-    [RouteContractOf<T>] extends [never]
-        ? never
-        : RouteContractOf<T> extends { response: infer TResponse }
-          ? TResponse
-          : never;
+export type ResponseOf<T> = [RouteContractOf<T>] extends [never]
+    ? never
+    : RouteContractOf<T> extends { response: infer TResponse }
+      ? TResponse
+      : never;
 
 export const formSafeOptions = (
     method: Method,

--- a/src/Converters/Routes.php
+++ b/src/Converters/Routes.php
@@ -307,12 +307,13 @@ class Routes extends Converter
     protected function appendCommonImports(Collection $routes, string $path): void
     {
         $pathKey = Import::relativePathFromFile($path, 'index');
-
+        $typesPathKey = Import::relativePathFromFile($path, 'types');
         $this->imports[$path] ??= new Imports;
 
         $this->imports[$path]->add($pathKey, 'queryParams');
         $this->imports[$path]->addType($pathKey, 'RouteQueryOptions');
         $this->imports[$path]->addType($pathKey, 'RouteDefinition');
+        $this->imports[$path]->addType($typesPathKey, $this->contractNamespaces($routes));
 
         if ($this->generateFormVariants()) {
             $this->imports[$path]->addType($pathKey, 'RouteFormDefinition');
@@ -329,5 +330,16 @@ class Routes extends Converter
         if ($routes->first(fn (Route $route) => $route->parameters()->isNotEmpty())) {
             $this->imports[$path]->add($pathKey, 'applyUrlDefaults');
         }
+    }
+
+    protected function contractNamespaces(Collection $routes): array
+    {
+        return $routes
+            ->map(fn (Route $route) => str($route->controller())->ltrim('\\')->before('\\')->toString())
+            ->filter()
+            ->map(fn (string $namespace) => TypeScript::safeMethod($namespace, '_'))
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/src/Langs/TypeScript/Converters/RouteMethod.php
+++ b/src/Langs/TypeScript/Converters/RouteMethod.php
@@ -3,6 +3,9 @@
 namespace Laravel\Wayfinder\Langs\TypeScript\Converters;
 
 use Laravel\Ranger\Components\InertiaResponse;
+use Laravel\Ranger\Components\JsonApiResponse;
+use Laravel\Ranger\Components\JsonResponse;
+use Laravel\Ranger\Components\ResourceResponse;
 use Laravel\Ranger\Components\Route;
 use Laravel\Ranger\Support\Verb;
 use Laravel\Wayfinder\Langs\TypeScript;
@@ -123,7 +126,7 @@ class RouteMethod
 
         $func = TypeScript::arrowFunction($this->name)
             ->export($this->named || ! $this->route->hasInvokableController())
-            ->returnType('RouteDefinition<"'.$this->route->verbs()->first()->actual.'">')
+            ->returnType($this->routeDefinitionType('"'.$this->route->verbs()->first()->actual.'"'))
             ->body($object);
 
         if ($this->hasParameters) {
@@ -202,10 +205,7 @@ class RouteMethod
 
         $componentType = $this->inertiaComponentType();
 
-        $def->satisfies($componentType
-            ? 'RouteDefinition<'.$verbs.', '.$componentType.'>'
-            : 'RouteDefinition<'.$verbs.'>'
-        );
+        $def->satisfies($this->routeDefinitionType($verbs, $componentType));
 
         return "{$this->name}.definition = {$def}";
     }
@@ -357,7 +357,7 @@ class RouteMethod
         }
 
         $func->argument($this->optionsParam, 'RouteQueryOptions', true);
-        $func->returnType('RouteDefinition<"'.$verb->actual.'">');
+        $func->returnType($this->routeDefinitionType('"'.$verb->actual.'"'));
 
         $body = TypeScript::object();
 
@@ -400,7 +400,7 @@ class RouteMethod
         }
 
         $func->argument($this->optionsParam, 'RouteQueryOptions', true);
-        $func->returnType('RouteFormDefinition<"'.$verb->formSafe.'">');
+        $func->returnType($this->routeFormDefinitionType('"'.$verb->formSafe.'"'));
 
         $body = TypeScript::object();
 
@@ -626,5 +626,74 @@ class RouteMethod
         return $route->hasInvokableController()
             ? str($route->controller())->afterLast('\\')->toString()
             : $route->method();
+    }
+
+    protected function routeDefinitionType(string $methodType, ?string $componentType = null): string
+    {
+        return $this->routeContractType('RouteDefinition', $methodType, $componentType);
+    }
+
+    protected function routeFormDefinitionType(string $methodType, ?string $componentType = null): string
+    {
+        return $this->routeContractType('RouteFormDefinition', $methodType, $componentType);
+    }
+
+    protected function routeContractType(string $definitionType, string $methodType, ?string $componentType = null): string
+    {
+        $generics = [$methodType];
+        $requestType = $this->requestType();
+        $responseType = $this->responseType();
+
+        if ($componentType !== null || $requestType !== 'unknown' || $responseType !== 'unknown') {
+            $generics[] = $componentType ?? 'undefined';
+        }
+
+        if ($requestType !== 'unknown' || $responseType !== 'unknown') {
+            $generics[] = $requestType;
+            $generics[] = $responseType;
+        }
+
+        return $definitionType.'<'.implode(', ', $generics).'>';
+    }
+
+    protected function requestType(): string
+    {
+        return $this->controllerContractType('Request');
+    }
+
+    protected function responseType(): string
+    {
+        if (! $this->hasGeneratedResponseType()) {
+            return 'unknown';
+        }
+
+        return $this->controllerContractType('Response');
+    }
+
+    protected function controllerContractType(string $type): string
+    {
+        $controller = str($this->route->controller())->ltrim('\\')->toString();
+
+        if ($controller === '') {
+            return 'unknown';
+        }
+
+        return collect([
+            ...explode('\\', $controller),
+            ucwords($this->route->method()),
+            $type,
+        ])
+            ->map(fn (string $part) => TypeScript::safeMethod($part, '_'))
+            ->implode('.');
+    }
+
+    protected function hasGeneratedResponseType(): bool
+    {
+        return collect($this->route->possibleResponses())
+            ->contains(fn ($response) => $response instanceof InertiaResponse
+                || $response instanceof JsonResponse
+                || $response instanceof ResourceResponse
+                || $response instanceof JsonApiResponse
+            );
     }
 }

--- a/tests/RouteContracts.test.ts
+++ b/tests/RouteContracts.test.ts
@@ -1,0 +1,41 @@
+import { expectTypeOf, test } from "vitest";
+import { store } from "../workbench/resources/js/wayfinder/App/Http/Controllers/PostController";
+import { show } from "../workbench/resources/js/wayfinder/App/Http/Controllers/ResourceTestController";
+import type { RequestOf, ResponseOf } from "../workbench/resources/js/wayfinder";
+import type { App } from "../workbench/resources/js/wayfinder/types";
+
+test("infers request types from route functions", () => {
+    expectTypeOf<RequestOf<typeof store>>().toEqualTypeOf<
+        App.Http.Controllers.PostController.Store.Request
+    >();
+
+    expectTypeOf<RequestOf<typeof store.post>>().toEqualTypeOf<
+        App.Http.Controllers.PostController.Store.Request
+    >();
+
+    expectTypeOf<RequestOf<typeof store.form>>().toEqualTypeOf<
+        App.Http.Controllers.PostController.Store.Request
+    >();
+});
+
+test("infers response types from route functions", () => {
+    expectTypeOf<ResponseOf<typeof show>>().toEqualTypeOf<
+        App.Http.Controllers.ResourceTestController.Show.Response
+    >();
+
+    expectTypeOf<ResponseOf<ReturnType<typeof show>>>().toEqualTypeOf<
+        App.Http.Controllers.ResourceTestController.Show.Response
+    >();
+
+    expectTypeOf<ResponseOf<typeof show.get>>().toEqualTypeOf<
+        App.Http.Controllers.ResourceTestController.Show.Response
+    >();
+
+    expectTypeOf<RequestOf<typeof show>>().toEqualTypeOf<
+        App.Http.Controllers.ResourceTestController.Show.Request
+    >();
+});
+
+test("does not infer contracts from plain route-like objects", () => {
+    expectTypeOf<ResponseOf<{ url: string }>>().toEqualTypeOf<never>();
+});


### PR DESCRIPTION
## Summary

Adds type-only request and response contracts to generated Wayfinder route definitions.

Generated route functions now carry the existing controller `Request` and `Response` types from `types.d.ts`, and the runtime helper exports `RequestOf<T>` and `ResponseOf<T>` so users can infer those contracts in typed fetch clients, form helpers, and integration code.

## Why

Wayfinder already generates request and response types, but consumers have to manually reference the matching namespace. This connects those generated types back to the route functions without adding runtime behavior or a new runtime helper API.

## Changes

- Adds type-only route contract metadata to `RouteDefinition` and `RouteFormDefinition`
- Adds `RequestOf<T>` and `ResponseOf<T>` helper types
- Generates route return types with matching controller request and response contracts
- Imports generated top-level namespaces from `types.d.ts` as type-only imports
- Adds type-level regression coverage
- Documents the new route type helpers

## Tests

- `composer format`
- `npm test`