### PR TITLE
Support boolean query parameter arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Add query parameters to any route:
 PostController.index({ query: { page: 2, sort: "created_at" } });
 // { url: '/posts?page=2&sort=created_at', method: 'get' }
 
+PostController.index({ query: { active: [true, false] } });
+// { url: '/posts?active[]=1&active[]=0', method: 'get' }
+
 // Merge with existing query string
 PostController.index({ mergeQuery: { page: 3 } });
 ```

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -1,16 +1,15 @@
+type QueryParamValue = string | number | boolean;
+
 export type QueryParams = {
     [key: string]:
-        | string
-        | number
-        | boolean
-        | (string | number)[]
+        | QueryParamValue
+        | readonly QueryParamValue[]
         | null
         | undefined
         | QueryParams;
 };
 
 type Method = "get" | "post" | "put" | "delete" | "patch" | "head" | "options";
-type ParamValue = string | number | boolean;
 type UrlDefaults = Record<string, unknown>;
 
 let urlDefaults: () => UrlDefaults = () => ({});
@@ -47,7 +46,7 @@ export const formSafeOptions = (
     },
 });
 
-const getValue = (value: ParamValue) => {
+const getValue = (value: QueryParamValue) => {
     if (value === true) {
         return "1";
     }
@@ -58,6 +57,10 @@ const getValue = (value: ParamValue) => {
 
     return value.toString();
 };
+
+const isQueryParamArray = (
+    value: unknown,
+): value is readonly QueryParamValue[] => Array.isArray(value);
 
 const addNestedParams = (
     obj: QueryParams,
@@ -71,7 +74,7 @@ const addNestedParams = (
 
         const paramKey = `${prefix}[${subKey}]`;
 
-        if (Array.isArray(value)) {
+        if (isQueryParamArray(value)) {
             value.forEach((v) => params.append(`${paramKey}[]`, getValue(v)));
         } else if (value !== null && typeof value === "object") {
             addNestedParams(value, paramKey, params);
@@ -118,9 +121,9 @@ export const queryParams = (options?: RouteQueryOptions) => {
             continue;
         }
 
-        if (Array.isArray(queryValue)) {
+        if (isQueryParamArray(queryValue)) {
             queryValue.forEach((value) => {
-                params.append(`${key}[]`, value.toString());
+                params.append(`${key}[]`, getValue(value));
             });
         } else if (typeof queryValue === "object") {
             addNestedParams(queryValue, key, params);

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -1,4 +1,4 @@
-type QueryParamValue = string | number | boolean;
+export type QueryParamValue = string | number | boolean;
 
 export type QueryParams = {
     [key: string]:

--- a/tests/QueryParams.test.ts
+++ b/tests/QueryParams.test.ts
@@ -29,6 +29,34 @@ it("can convert array params", () => {
     });
 });
 
+it("can convert readonly array params", () => {
+    const tags = ["bar", "baz"] as const;
+
+    expect(
+        index({
+            query: {
+                tags,
+            },
+        })
+    ).toEqual({
+        url: "/posts?tags%5B%5D=bar&tags%5B%5D=baz",
+        method: "get",
+    });
+});
+
+it("can convert boolean array params", () => {
+    expect(
+        index({
+            query: {
+                active: [true, false],
+            },
+        })
+    ).toEqual({
+        url: "/posts?active%5B%5D=1&active%5B%5D=0",
+        method: "get",
+    });
+});
+
 it("can convert object params", () => {
     expect(
         index({
@@ -42,6 +70,21 @@ it("can convert object params", () => {
         })
     ).toEqual({
         url: "/posts?foo%5Ba%5D=baz&foo%5Bb%5D=qux&bar=something",
+        method: "get",
+    });
+});
+
+it("can convert nested boolean array params", () => {
+    expect(
+        index({
+            query: {
+                filters: {
+                    active: [true, false],
+                },
+            },
+        })
+    ).toEqual({
+        url: "/posts?filters%5Bactive%5D%5B%5D=1&filters%5Bactive%5D%5B%5D=0",
         method: "get",
     });
 });


### PR DESCRIPTION
## Summary

Allows Wayfinder query parameters to accept boolean arrays and readonly arrays.

Array query values now use the same boolean normalization as scalar query values, so `true` becomes `1` and `false` becomes `0`. The `QueryParams` type also accepts readonly arrays, which lets callers pass tuple literals or `as const` arrays without widening them manually.

## Why

Wayfinder already supports scalar booleans in query strings. Arrays should behave the same way, and readonly arrays are common when query values come from typed constants.

## Changes

- Adds a shared `QueryParamValue` primitive type
- Allows `readonly QueryParamValue[]` in `QueryParams`
- Serializes array values through `getValue`
- Adds coverage for readonly arrays, boolean arrays, and nested boolean arrays
- Documents boolean query array output

## Tests

- `npm run format`
- `npx vitest run tests/QueryParams.test.ts`
- `npm run tsc:wayfinder`
- `npm run lint`
- `WAYFINDER_GENERATE_INERTIA_COMPONENT=1 npx vitest run tests/InertiaComponent.test.ts`
- `npm run tsc`
- `npm test`