### PR TITLE
Add scoped URL defaults helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ PostController.edit.url({ post: 42 });
 // '/posts/42/edit'
 ```
 
+### URL Defaults
+
+Set frontend URL defaults for route parameters such as locales or tenant domains:
+
+```typescript
+import { setUrlDefaults, withUrlDefaults } from "@/wayfinder";
+
+setUrlDefaults({ locale: "en" });
+
+const frenchUrl = withUrlDefaults({ locale: "fr" }, () =>
+    PostController.index.url()
+);
+```
+
+Scoped defaults are merged with the existing defaults and restored when the callback finishes or settles.
+
 ### Query Parameters
 
 Add query parameters to any route:

--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -175,6 +175,37 @@ export const addUrlDefault = (
     });
 };
 
+export const withUrlDefaults = <T>(
+    params: UrlDefaults | (() => UrlDefaults),
+    callback: () => T,
+): T => {
+    const previousDefaults = urlDefaults;
+    const scopedDefaults = typeof params === "function" ? params : () => params;
+
+    urlDefaults = () => ({
+        ...previousDefaults(),
+        ...scopedDefaults(),
+    });
+
+    try {
+        const result = callback();
+
+        if (result instanceof Promise) {
+            return result.finally(() => {
+                urlDefaults = previousDefaults;
+            }) as T;
+        }
+
+        urlDefaults = previousDefaults;
+
+        return result;
+    } catch (error) {
+        urlDefaults = previousDefaults;
+
+        throw error;
+    }
+};
+
 export const applyUrlDefaults = <T extends UrlDefaults | undefined>(
     existing: T,
 ): T => {

--- a/tests/DefaultParameters.test.ts
+++ b/tests/DefaultParameters.test.ts
@@ -3,6 +3,7 @@ import {
     addUrlDefault,
     applyUrlDefaults,
     setUrlDefaults,
+    withUrlDefaults,
 } from "../workbench/resources/js/wayfinder";
 import {
     defaultParametersDomain,
@@ -76,4 +77,108 @@ test("it preserves dynamic URL defaults when adding runtime defaults", () => {
     });
 
     expect(callCount).toBe(2);
+});
+
+test("it applies scoped URL defaults for a callback", () => {
+    setUrlDefaults({
+        defaultDomain: "base.test",
+        locale: "en",
+    });
+
+    expect(
+        withUrlDefaults(
+            {
+                locale: "fr",
+            },
+            () => applyUrlDefaults(undefined)
+        )
+    ).toEqual({
+        defaultDomain: "base.test",
+        locale: "fr",
+    });
+
+    expect(applyUrlDefaults(undefined)).toEqual({
+        defaultDomain: "base.test",
+        locale: "en",
+    });
+});
+
+test("it preserves dynamic URL defaults when applying scoped defaults", () => {
+    let callCount = 0;
+
+    setUrlDefaults(() => {
+        callCount++;
+
+        return {
+            defaultDomain: `dynamic-${callCount}.test`,
+        };
+    });
+
+    expect(
+        withUrlDefaults(
+            {
+                locale: "en",
+            },
+            () => applyUrlDefaults(undefined)
+        )
+    ).toEqual({
+        defaultDomain: "dynamic-1.test",
+        locale: "en",
+    });
+
+    expect(applyUrlDefaults(undefined)).toEqual({
+        defaultDomain: "dynamic-2.test",
+    });
+
+    expect(callCount).toBe(2);
+});
+
+test("it restores URL defaults after an async callback settles", async () => {
+    setUrlDefaults({
+        defaultDomain: "base.test",
+    });
+
+    await expect(
+        withUrlDefaults(
+            {
+                defaultDomain: "async.test",
+            },
+            async () => {
+                await Promise.resolve();
+
+                return defaultParametersDomain.url({
+                    param: "foo",
+                });
+            }
+        )
+    ).resolves.toBe("//async.test.au/default-parameters-domain/foo");
+
+    expect(
+        defaultParametersDomain.url({
+            param: "foo",
+        })
+    ).toBe("//base.test.au/default-parameters-domain/foo");
+});
+
+test("it restores URL defaults after a callback throws", () => {
+    setUrlDefaults({
+        defaultDomain: "base.test",
+    });
+
+    expect(() =>
+        withUrlDefaults(
+            {
+                defaultDomain: "scoped.test",
+            },
+            () => {
+                throw new Error("Scoped failure");
+            }
+        )
+    ).toThrow("Scoped failure");
+
+    expect(
+        defaultParametersDomain.url({
+            param: "foo",
+        })
+    ).toBe("//base.test.au/default-parameters-domain/foo");
 });


### PR DESCRIPTION
## Summary

Adds a `withUrlDefaults` runtime helper for temporarily applying frontend URL defaults while a callback runs.

Scoped defaults are merged on top of the current defaults, so existing static or dynamic defaults are preserved. The previous defaults are restored after the callback returns, throws, or an async callback settles.

## Why

Wayfinder already lets callers set global URL defaults and add a single default. In apps with locale, tenant, or domain defaults, it is useful to override those defaults for one operation without manually replacing global state or losing dynamic defaults.

## Changes

- Adds `withUrlDefaults(defaults, callback)` to the generated Wayfinder runtime
- Preserves existing dynamic URL defaults while scoped defaults are active
- Restores prior defaults after sync callbacks, async callbacks, and thrown errors
- Adds coverage for scoped overrides, dynamic defaults, async callbacks, and error restoration
- Documents scoped URL defaults in the README

## Tests

- `npm run format`
- `npx vitest run tests/DefaultParameters.test.ts`
- `npm run tsc:wayfinder`
- `npm run lint`
- `WAYFINDER_GENERATE_INERTIA_COMPONENT=1 npx vitest run tests/InertiaComponent.test.ts`
- `npm run tsc`
- `npm test`