### PR TITLE
[next] Support AsStringable model cast

### DIFF
--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -106,6 +106,7 @@ class TypeScriptConverter extends AbstractConverter
 
         $matched = match (true) {
             $class === Stringable::class => 'string',
+            $class === 'Illuminate\Database\Eloquent\Casts\AsStringable' => 'string',
             is_a($class, DateTimeInterface::class, true) => 'string',
             is_a($class, Collection::class, true) => $this->convertCollectionType($result),
             default => null,

--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -3,6 +3,7 @@
 namespace Laravel\Wayfinder\Registry;
 
 use DateTimeInterface;
+use Illuminate\Database\Eloquent\Casts\AsStringable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use InvalidArgumentException;
@@ -106,7 +107,7 @@ class TypeScriptConverter extends AbstractConverter
 
         $matched = match (true) {
             $class === Stringable::class => 'string',
-            $class === 'Illuminate\Database\Eloquent\Casts\AsStringable' => 'string',
+            $class === AsStringable::class => 'string',
             is_a($class, DateTimeInterface::class, true) => 'string',
             is_a($class, Collection::class, true) => $this->convertCollectionType($result),
             default => null,


### PR DESCRIPTION
This handles the `AsStringable` model cast to convert it to a string.

I went with using the class name as an real string to avoid adding illuminate/database as a dependency. I see it's already pulled in as a sub of something else though anyway. Let me know if you want to just use the `::class` syntax in that case.

I also actually believe PHP would handle attempting to `use` and reference it purely through `AsStringable::class` without errors since it doesn't actually load the class - but that feels risky.