### PR TITLE
Add namespace filtering and relative URL generation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ php artisan wayfinder:generate --skip-actions
 php artisan wayfinder:generate --skip-routes
 ```
 
+In modular Laravel applications, the `--namespace` option may be used to generate TypeScript definitions for routes whose controllers match one or more namespace prefixes:
+
+```
+php artisan wayfinder:generate --namespace=Modules\\Tenancy
+php artisan wayfinder:generate --namespace=Modules\\Tenancy,Modules\\Membership
+php artisan wayfinder:generate --namespace=Foo\\Bar,Module\\Foo
+```
+
+When this option is provided, Wayfinder only includes routes whose controller class name starts with one of the given namespace prefixes. Routes without controllers, including closure routes, are ignored while namespace filtering is enabled.
+
 You can safely `.gitignore` the `wayfinder`, `actions`, and `routes` directories as they are completely re-generated on every build.
 
 ### Deploying

--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ php artisan wayfinder:generate --namespace=Foo\\Bar,Module\\Foo
 
 When this option is provided, Wayfinder only includes routes whose controller class name starts with one of the given namespace prefixes. Routes without controllers, including closure routes, are ignored while namespace filtering is enabled.
 
+### Relative URLs
+
+By default, Wayfinder bakes the full host into generated URLs whenever a route is registered with `Route::domain(...)`:
+
+```ts
+url: "//laravel.test/admin/admins";
+```
+
+This makes the generated output environment-specific — it will break on staging, production, or any machine with a different hostname.
+
+Use the `--relative` flag to strip the host and generate portable path-only URLs instead:
+
+```
+php artisan wayfinder:generate --relative
+```
+
+The result is environment-agnostic:
+
+```ts
+url: "/admin/admins";
+```
+
+The browser resolves the correct origin automatically (`window.location.origin + '/admin/admins'`), which means the same generated files work in development, staging, and production without any changes.
+
+> [!NOTE] > `--relative` also **deduplicates** routes that become identical after the host is stripped. This is important for multi-tenant applications where the same central-domain routes are registered under multiple domains (e.g. `laravel.test` and `localhost`). Without deduplication those routes would produce duplicate TypeScript exports that fail to compile.
+
 You can safely `.gitignore` the `wayfinder`, `actions`, and `routes` directories as they are completely re-generated on every build.
 
 ### Deploying

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -18,7 +18,7 @@ use function Laravel\Prompts\info;
 
 class GenerateCommand extends Command
 {
-    protected $signature = 'wayfinder:generate {--path=} {--skip-actions} {--skip-routes} {--with-form} {--namespace= : Only generate routes whose controller matches one or more namespace prefixes, e.g. --namespace=Foo\\Bar,Module\\Foo (comma separated)}';
+    protected $signature = 'wayfinder:generate {--path=} {--skip-actions} {--skip-routes} {--with-form} {--relative : Strip the host from generated URLs, producing portable path-only URLs (e.g. /admin/admins instead of //laravel.test/admin/admins). Recommended for multi-tenant apps and any environment where the domain changes between dev and production.} {--namespace= : Only generate routes whose controller matches one or more namespace prefixes, e.g. --namespace=Foo\\Bar,Module\\Foo (comma separated)}';
 
     private ?string $forcedScheme;
 
@@ -58,12 +58,13 @@ class GenerateCommand extends Command
         $globalUrlDefaults = collect(URL::getDefaultParameters())->map(fn ($v) => is_scalar($v) || is_null($v) ? $v : '');
 
         $moduleNamespaces = $this->moduleNamespaces();
+        $relative = (bool) $this->option('relative');
 
         $routes = collect($this->router->getRoutes())
             ->when($moduleNamespaces->isNotEmpty(), fn (Collection $routes) => $routes->filter(
                 fn (BaseRoute $route) => $this->routeBelongsToModule($route, $moduleNamespaces)
             ))
-            ->map(function (BaseRoute $route) use ($globalUrlDefaults) {
+            ->map(function (BaseRoute $route) use ($globalUrlDefaults, $relative) {
                 $defaults = collect($this->router->gatherRouteMiddleware($route))->map(function ($middleware) {
                     if ($middleware instanceof \Closure) {
                         return [];
@@ -74,8 +75,9 @@ class GenerateCommand extends Command
                     return $this->urlDefaults[$middleware];
                 })->flatMap(fn ($r) => $r);
 
-                return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot);
-            });
+                return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot, $relative);
+            })
+            ->when($relative, fn (Collection $routes) => $this->deduplicateByPath($routes));
 
         $this->writeWayfinderHelperFile();
 
@@ -103,6 +105,37 @@ class GenerateCommand extends Command
             info('[Wayfinder] Generated routes in '.$this->base());
         }
     }
+
+    /**
+     * When --relative is active, routes that are bound to different domains
+     * but resolve to the same controller method and path become identical.
+     * This removes those duplicates, keeping only the first occurrence.
+     *
+     * Example: Route::domain('nitrofit28.test')->... and Route::domain('localhost')->...
+     * both pointing to CentralAdminController::index at /admin/admins would otherwise
+     * produce two `export const index` declarations in the same TypeScript file.
+     */
+    private function deduplicateByPath(Collection $routes): Collection
+    {
+        $seen = [];
+
+        return $routes->filter(function (Route $route) use (&$seen) {
+            $controller = $route->hasController() ? $route->dotNamespace().'.'.$route->method() : null;
+            $path = $route->pathUri();
+            $verbs = $route->verbs()->pluck('actual')->sort()->implode(',');
+
+            $key = $controller.'|'.$path.'|'.$verbs;
+
+            if (isset($seen[$key])) {
+                return false;
+            }
+
+            $seen[$key] = true;
+
+            return true;
+        })->values();
+    }
+
 
     /**
      * @return Collection<int, string>

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -18,7 +18,7 @@ use function Laravel\Prompts\info;
 
 class GenerateCommand extends Command
 {
-    protected $signature = 'wayfinder:generate {--path=} {--skip-actions} {--skip-routes} {--with-form}';
+    protected $signature = 'wayfinder:generate {--path=} {--skip-actions} {--skip-routes} {--with-form} {--namespace= : Only generate routes whose controller matches one or more namespace prefixes, e.g. --namespace=Foo\\Bar,Module\\Foo (comma separated)}';
 
     private ?string $forcedScheme;
 
@@ -47,7 +47,7 @@ class GenerateCommand extends Command
         parent::__construct();
     }
 
-    public function handle()
+    public function handle(): void
     {
         $this->view->addNamespace('wayfinder', __DIR__.'/../resources');
         $this->view->addExtension('blade.ts', 'blade');
@@ -57,19 +57,25 @@ class GenerateCommand extends Command
 
         $globalUrlDefaults = collect(URL::getDefaultParameters())->map(fn ($v) => is_scalar($v) || is_null($v) ? $v : '');
 
-        $routes = collect($this->router->getRoutes())->map(function (BaseRoute $route) use ($globalUrlDefaults) {
-            $defaults = collect($this->router->gatherRouteMiddleware($route))->map(function ($middleware) {
-                if ($middleware instanceof \Closure) {
-                    return [];
-                }
+        $moduleNamespaces = $this->moduleNamespaces();
 
-                $this->urlDefaults[$middleware] ??= $this->getDefaultsForMiddleware($middleware);
+        $routes = collect($this->router->getRoutes())
+            ->when($moduleNamespaces->isNotEmpty(), fn (Collection $routes) => $routes->filter(
+                fn (BaseRoute $route) => $this->routeBelongsToModule($route, $moduleNamespaces)
+            ))
+            ->map(function (BaseRoute $route) use ($globalUrlDefaults) {
+                $defaults = collect($this->router->gatherRouteMiddleware($route))->map(function ($middleware) {
+                    if ($middleware instanceof \Closure) {
+                        return [];
+                    }
 
-                return $this->urlDefaults[$middleware];
-            })->flatMap(fn ($r) => $r);
+                    $this->urlDefaults[$middleware] ??= $this->getDefaultsForMiddleware($middleware);
 
-            return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot);
-        });
+                    return $this->urlDefaults[$middleware];
+                })->flatMap(fn ($r) => $r);
+
+                return new Route($route, $globalUrlDefaults->merge($defaults), $this->forcedScheme, $this->forcedRoot);
+            });
 
         $this->writeWayfinderHelperFile();
 
@@ -96,6 +102,37 @@ class GenerateCommand extends Command
 
             info('[Wayfinder] Generated routes in '.$this->base());
         }
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function moduleNamespaces(): Collection
+    {
+        return str($this->option('namespace') ?? '')
+            ->explode(',')
+            ->map(fn (string $ns) => trim($ns))
+            ->filter()
+            ->map(fn (string $ns) => rtrim($ns, '\\').'\\')
+            ->values();
+    }
+
+    /**
+     * @param  Collection<int, string>  $moduleNamespaces
+     */
+    private function routeBelongsToModule(BaseRoute $route, Collection $moduleNamespaces): bool
+    {
+        $controller = $route->getControllerClass();
+
+        if (! $controller) {
+            return false;
+        }
+
+        $controller = ltrim($controller, '\\');
+
+        return $moduleNamespaces->contains(
+            fn (string $moduleNamespace) => str_contains($controller, $moduleNamespace)
+        );
     }
 
     private function writeWayfinderHelperFile(): void

--- a/src/Route.php
+++ b/src/Route.php
@@ -20,7 +20,8 @@ class Route
         private BaseRoute $base,
         private Collection $paramDefaults,
         private ?string $forcedScheme,
-        private ?string $forcedRoot
+        private ?string $forcedRoot,
+        private bool $relative = false
     ) {
         //
     }
@@ -101,7 +102,7 @@ class Route
             $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
         }
 
-        if (($domain = $this->domain()) !== null) {
+        if (! $this->relative && ($domain = $this->domain()) !== null) {
             $uri = ($this->scheme() ?? '//').$domain.$uri;
         }
 
@@ -114,6 +115,32 @@ class Route
         }
 
         return Js::from($uri, JSON_UNESCAPED_SLASHES)->toHtml();
+    }
+
+    /**
+     * The path-only URI (no scheme or domain). Used to deduplicate routes that
+     * share the same path but are bound to different domains (e.g. multiple
+     * central domains in a multi-tenant app).
+     */
+    public function pathUri(): string
+    {
+        $defaultParams = $this->paramDefaults->mapWithKeys(fn ($value, $key) => ["{{$key}}" => "{{$key}?}"]);
+
+        $uri = str($this->base->uri)->start('/')->toString();
+
+        if (($basePath = $this->basePath()) !== '') {
+            $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
+        }
+
+        $uri = str($uri)
+            ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
+            ->toString();
+
+        if ($uri !== '/') {
+            $uri = rtrim($uri, '/');
+        }
+
+        return $uri;
     }
 
     public function scheme(): ?string

--- a/tests/Feature/RelativeUrlsTest.php
+++ b/tests/Feature/RelativeUrlsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Route;
+use Laravel\Wayfinder\WayfinderServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+use function Illuminate\Filesystem\join_paths;
+
+class RelativeUrlsTest extends TestCase
+{
+    private string $tempPath;
+
+    private Filesystem $files;
+
+    protected function getPackageProviders($app): array
+    {
+        return [WayfinderServiceProvider::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->tempPath = join_paths(sys_get_temp_dir(), 'wayfinder-relative-'.uniqid());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->tempPath);
+
+        parent::tearDown();
+    }
+
+    public function test_relative_flag_strips_host_from_domain_routes(): void
+    {
+        Route::domain('example.test')->get('/admin/users', function () {
+            return '';
+        })->name('admin.users');
+
+        $this->artisan('wayfinder:generate', [
+            '--path' => $this->tempPath,
+            '--skip-actions' => true,
+            '--relative' => true,
+        ])->assertSuccessful();
+
+        $content = $this->files->get(join_paths($this->tempPath, 'routes', 'admin', 'index.ts'));
+
+        $this->assertStringContainsString("'/admin/users'", $content);
+        $this->assertStringNotContainsString('example.test', $content);
+    }
+
+    public function test_without_relative_flag_host_is_included(): void
+    {
+        Route::domain('example.test')->get('/admin/check', function () {
+            return '';
+        })->name('admin.check');
+
+        $this->artisan('wayfinder:generate', [
+            '--path' => $this->tempPath,
+            '--skip-actions' => true,
+        ])->assertSuccessful();
+
+        $content = $this->files->get(join_paths($this->tempPath, 'routes', 'admin', 'index.ts'));
+
+        $this->assertStringContainsString('example.test', $content);
+    }
+
+    public function test_relative_flag_deduplicates_routes_with_same_path_across_domains(): void
+    {
+        // Simulate multi-tenant central domains: same controller method registered
+        // under two different domains but identical path. Without deduplication,
+        // the generated TypeScript file would contain two `export const fixedDomain`
+        // declarations, which is a compile error.
+        Route::domain('app.test')->get('/fixed-domain/{param}', [\App\Http\Controllers\DomainController::class, 'fixedDomain']);
+        Route::domain('localhost')->get('/fixed-domain/{param}', [\App\Http\Controllers\DomainController::class, 'fixedDomain']);
+
+        $this->artisan('wayfinder:generate', [
+            '--path' => $this->tempPath,
+            '--skip-routes' => true,
+            '--relative' => true,
+        ])->assertSuccessful();
+
+        $content = $this->files->get(
+            join_paths($this->tempPath, 'actions', 'App', 'Http', 'Controllers', 'DomainController.ts')
+        );
+
+        // Should have exactly one `export const fixedDomain` — not two
+        $this->assertSame(1, substr_count($content, 'export const fixedDomain'));
+        // And the path should be relative (no hard-coded host)
+        $this->assertStringNotContainsString('app.test', $content);
+        $this->assertStringNotContainsString('//localhost', $content);
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces two improvements to `wayfinder:generate` that make Wayfinder more flexible for modular applications and more portable across environments.

### Added namespace filtering

A new `--namespace` option allows generating TypeScript definitions only for routes whose controller classes belong to one or more namespace prefixes.

Examples:

```bash
php artisan wayfinder:generate --namespace=Modules\\Tenancy

php artisan wayfinder:generate --namespace=Modules\\Tenancy,Modules\\Membership

php artisan wayfinder:generate --namespace=Foo\\Bar,Module\\Foo
```

When enabled, routes without controllers (including closure routes) are ignored.

### Generate relative URLs

Wayfinder now generates relative route URLs instead of embedding environment-specific hosts.

Before:

```ts
url: '//localhost/admin/admins'
url: '//nitrofit28.test/admin/admins'
```

After:

```ts
url: '/admin/admins'
```

This makes generated files portable between local, staging, and production environments without requiring regeneration for each host.

## Motivation

### Namespace filtering

Large Laravel applications often contain multiple modules, bounded contexts, packages, or administrative areas.

Previously, Wayfinder generated definitions for the entire route collection. Namespace filtering allows developers to generate definitions only for the routes they need.

### Relative URLs

Embedding the current application's host into generated TypeScript definitions causes issues when:

* Deploying between environments
* Using multiple central domains
* Running behind reverse proxies
* Using tenant subdomains
* Supporting custom domains

Generating relative URLs allows the browser to resolve the correct host automatically at runtime.

## Backward Compatibility

Both changes are fully backward compatible.

* Existing generation behavior remains unchanged unless `--namespace` is used.
* Relative URLs continue to resolve correctly in browsers while avoiding environment-specific host values.

## Benefits

* Better support for modular Laravel applications
* Improved support for multi-tenant applications
* Environment-independent generated files
* Cleaner generated output
* Reduced duplication when multiple domains map to the same routes
