### PR TITLE
Add escaped string literal support in enums and validation rules

### DIFF
--- a/src/Converters/Enums.php
+++ b/src/Converters/Enums.php
@@ -19,7 +19,7 @@ class Enums extends Converter
                 $name,
                 TypeScript::union(
                     collect($enum->cases)
-                        ->map(fn ($case) => is_string($case) ? "'{$case}'" : (string) $case)
+                        ->map(fn ($case) => is_string($case) ? TypeScript::stringLiteral($case) : (string) $case)
                         ->values()
                         ->all(),
                 ),
@@ -36,7 +36,7 @@ class Enums extends Converter
             }
 
             if (is_string($value)) {
-                $content[] = TypeScript::constant($case, TypeScript::quote($value))->export();
+                $content[] = TypeScript::constant($case, TypeScript::stringLiteral($value))->export();
             } else {
                 $content[] = TypeScript::constant($case, $value)->export();
             }
@@ -48,7 +48,7 @@ class Enums extends Converter
 
         foreach ($enum->cases as $case => $value) {
             if (in_array($case, TypeScript::RESERVED_KEYWORDS, true)) {
-                $literal = is_string($value) ? TypeScript::quote($value) : (string) $value;
+                $literal = is_string($value) ? TypeScript::stringLiteral($value) : (string) $value;
                 $obj->key($case)->value($literal);
             } else {
                 $obj->key($case)->value($case);

--- a/src/Langs/WritesJavaScript.php
+++ b/src/Langs/WritesJavaScript.php
@@ -20,6 +20,11 @@ trait WritesJavaScript
         return '"'.$string.'"';
     }
 
+    public static function stringLiteral(string $string): string
+    {
+        return json_encode($string, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
     public static function quoteKey(string $key): string
     {
         if (str_starts_with($key, '[')) {
@@ -30,7 +35,7 @@ trait WritesJavaScript
             return $key;
         }
 
-        return self::quote($key);
+        return self::stringLiteral($key);
     }
 
     protected static function splitOn(string $str, string $separator): array

--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -36,7 +36,7 @@ class Rules
         if ($inRule = $this->getRule('In')) {
             return collect($inRule->getParams())
                 ->filter(fn ($v) => ! is_null($v) && $v !== '')
-                ->map(TypeScript::quote(...))
+                ->map(fn ($v) => TypeScript::stringLiteral((string) $v))
                 ->implode(' | ');
         }
 

--- a/tests/Enums.test.ts
+++ b/tests/Enums.test.ts
@@ -12,6 +12,14 @@ import {
     used,
     Active,
 } from "../workbench/resources/js/wayfinder/App/Enums/ProductStatus";
+import {
+    EscapedStatus,
+    Quote,
+    StartsWithQuote,
+    Backtick,
+    Backslash,
+    Newline, LiteralBackslash, LiteralBacktick,
+} from "../workbench/resources/js/wayfinder/App/Enums/EscapedStatus";
 
 describe("Enums", () => {
     test("exports enum constant object", () => {
@@ -46,6 +54,18 @@ describe("Enums", () => {
     test("namespaced string-backed enum type is a string union", () => {
         expectTypeOf<App.Enums.PostStatus>().toEqualTypeOf<
             "draft" | "published" | "archived"
+        >();
+    });
+
+    test("namespaced escaped string-backed enum type is a string union", () => {
+        expectTypeOf<App.Enums.EscapedStatus>().toEqualTypeOf<
+            | "\\"
+            | "`"
+            | 'they said "yes"'
+            | '"quoted"'
+            | "`template`"
+            | "path\\to\\file"
+            | "line\nbreak"
         >();
     });
 
@@ -84,5 +104,37 @@ describe("Enums", () => {
     test("only exports non-reserved case constants individually", () => {
         expect(used).toBe("used");
         expect(Active).toBe("active");
+    });
+
+    test("has correct enum cases requiring escaping", () => {
+        expect(EscapedStatus.LiteralBackslash).toBe("\\");
+        expect(EscapedStatus.LiteralBacktick).toBe("`");
+        expect(EscapedStatus.Quote).toBe('they said "yes"');
+        expect(EscapedStatus.StartsWithQuote).toBe('"quoted"');
+        expect(EscapedStatus.Backtick).toBe("`template`");
+        expect(EscapedStatus.Backslash).toBe("path\\to\\file");
+        expect(EscapedStatus.Newline).toBe("line\nbreak");
+    });
+
+    test("exposes all keys for enums requiring escaping", () => {
+        expect(Object.keys(EscapedStatus)).toEqual([
+            "LiteralBackslash",
+            "LiteralBacktick",
+            "Quote",
+            "StartsWithQuote",
+            "Backtick",
+            "Backslash",
+            "Newline",
+        ]);
+    });
+
+    test("exports individual escaped case constants", () => {
+        expect(LiteralBackslash).toBe("\\");
+        expect(LiteralBacktick).toBe("`");
+        expect(Quote).toBe('they said "yes"');
+        expect(StartsWithQuote).toBe('"quoted"');
+        expect(Backtick).toBe("`template`");
+        expect(Backslash).toBe("path\\to\\file");
+        expect(Newline).toBe("line\nbreak");
     });
 });

--- a/tests/FormRequests.test.ts
+++ b/tests/FormRequests.test.ts
@@ -25,4 +25,12 @@ describe("FormRequests", () => {
         expect(content).toContain("title");
         expect(content).toContain("body");
     });
+
+    test("StorePostRequest escapes in rule string literals", () => {
+        const content = readFileSync(typesPath, "utf-8");
+
+        expect(content).toContain(
+            'visibility?: "public" | "team \\"quoted\\"" | "prefixed" | "`template`" | "path\\\\to\\\\file" | null;'
+        );
+    });
 });

--- a/workbench/app/Enums/EscapedStatus.php
+++ b/workbench/app/Enums/EscapedStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum EscapedStatus: string
+{
+    case LiteralBackslash = '\\';
+    case LiteralBacktick = "`";
+    case Quote = 'they said "yes"';
+    case StartsWithQuote = '"quoted"';
+    case Backtick = '`template`';
+    case Backslash = 'path\\to\\file';
+    case Newline = "line\nbreak";
+}

--- a/workbench/app/Http/Requests/StorePostRequest.php
+++ b/workbench/app/Http/Requests/StorePostRequest.php
@@ -22,6 +22,7 @@ class StorePostRequest extends FormRequest
             'excerpt' => ['nullable', 'string', 'max:500'],
             'published_at' => ['nullable', 'date'],
             'author_email' => ['nullable', 'email'],
+            'visibility' => ['nullable', 'in:public,team "quoted","prefixed",`template`,path\\to\\file'],
             'tags' => ['nullable', 'array'],
             'tags.*' => ['string'],
             'meta' => ['nullable', 'array'],


### PR DESCRIPTION
## Summary
Ensures generated TypeScript for enums and validation rules are correctly escaped.

## Why
Admittedly an edge case, but an enum or validation rule with symbols (like backticks, quotes, and backslashes) in it may result in invalid TypeScript.

```php
enum EscapedStatus: string
{
    case LiteralBackslash = '\\';
    case LiteralBacktick = "`";
    case Quote = 'he said "yes"';
    case StartsWithQuote = '"quoted"';
    case Backtick = '`template`';
    case Backslash = 'path\\to\\file';
    case Newline = "line\nbreak";
}
```

```typescript
export const LiteralBackslash = "\"
export const LiteralBacktick = `
export const Quote = "they said "yes""
export const StartsWithQuote = "quoted"
export const Backtick = `template`
export const Backslash = "path\to\file"
export const Newline = "line
break"
```

This PR ensures the TypeScript is valid

```typescript
export const LiteralBackslash = "\\"
export const LiteralBacktick = "`"
export const Quote = "they said \"yes\""
export const StartsWithQuote = "\"quoted\""
export const Backtick = "`template`"
export const Backslash = "path\\to\\file"
export const Newline = "line\nbreak"
```