### PR TITLE
fix: type empty arrays as unknown[] instead of []

### DIFF
--- a/src/Registry/TypeScriptConverter.php
+++ b/src/Registry/TypeScriptConverter.php
@@ -62,6 +62,10 @@ class TypeScriptConverter extends AbstractConverter
         $nullSuffix = $result->isNullable() ? ' | null' : '';
 
         if (array_is_list($value)) {
+            if (empty($value)) {
+                return 'unknown[]'.$nullSuffix;
+            }
+
             $types = TypeScript::union(array_map($this->convert(...), $value));
 
             if (str_contains($types, '|')) {

--- a/tests/InertiaData.test.ts
+++ b/tests/InertiaData.test.ts
@@ -23,6 +23,11 @@ describe("InertiaData", () => {
         expect(content).toContain("Dashboard");
     });
 
+    test("empty array prop is typed as unknown[]", () => {
+        const content = readFileSync(typesPath, "utf-8");
+        expect(content).toContain("recentActivity?: unknown[]");
+    });
+
     test.skip("InertiaController action types directory exists", () => {
         const inertiaTypesPath = join(
             __dirname,

--- a/tests/Unit/Registry/TypeScriptConverterTest.php
+++ b/tests/Unit/Registry/TypeScriptConverterTest.php
@@ -52,22 +52,4 @@ class TypeScriptConverterTest extends TestCase
 
         $this->assertSame('unknown[]', $result);
     }
-
-    public function test_json_cast_produces_record_type(): void
-    {
-        $arrayShape = Types\Type::arrayShape(Types\Type::mixed(), Types\Type::mixed());
-
-        $result = $this->converter->convert($arrayShape);
-
-        $this->assertSame('Record<string, unknown>', $result);
-    }
-
-    public function test_array_cast_produces_array_type(): void
-    {
-        $arrayType = Types\Type::array([]);
-
-        $result = $this->converter->convert($arrayType);
-
-        $this->assertSame('unknown[]', $result);
-    }
 }

--- a/tests/Unit/Registry/TypeScriptConverterTest.php
+++ b/tests/Unit/Registry/TypeScriptConverterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Registry;
+
+use Laravel\Surveyor\Types;
+use Laravel\Wayfinder\Registry\TypeScriptConverter;
+use PHPUnit\Framework\TestCase;
+
+class TypeScriptConverterTest extends TestCase
+{
+    protected TypeScriptConverter $converter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->converter = new TypeScriptConverter;
+    }
+
+    public function test_array_shape_with_unknown_key_produces_record_type(): void
+    {
+        $arrayShape = Types\Type::arrayShape(Types\Type::mixed(), Types\Type::mixed());
+
+        $result = $this->converter->convert($arrayShape);
+
+        $this->assertSame('Record<string, unknown>', $result);
+    }
+
+    public function test_array_shape_with_number_key_produces_array_type(): void
+    {
+        $arrayShape = Types\Type::arrayShape(Types\Type::int(), Types\Type::string());
+
+        $result = $this->converter->convert($arrayShape);
+
+        $this->assertSame('string[]', $result);
+    }
+
+    public function test_array_shape_with_string_key_produces_record_type(): void
+    {
+        $arrayShape = Types\Type::arrayShape(Types\Type::string(), Types\Type::int());
+
+        $result = $this->converter->convert($arrayShape);
+
+        $this->assertSame('Record<string, number>', $result);
+    }
+
+    public function test_array_type_produces_array_type(): void
+    {
+        $arrayType = Types\Type::array([]);
+
+        $result = $this->converter->convert($arrayType);
+
+        $this->assertSame('unknown[]', $result);
+    }
+
+    public function test_json_cast_produces_record_type(): void
+    {
+        $arrayShape = Types\Type::arrayShape(Types\Type::mixed(), Types\Type::mixed());
+
+        $result = $this->converter->convert($arrayShape);
+
+        $this->assertSame('Record<string, unknown>', $result);
+    }
+
+    public function test_array_cast_produces_array_type(): void
+    {
+        $arrayType = Types\Type::array([]);
+
+        $result = $this->converter->convert($arrayType);
+
+        $this->assertSame('unknown[]', $result);
+    }
+}


### PR DESCRIPTION
Closes #277

> **Requires:** [laravel/surveyor#60](https://github.com/laravel/surveyor/pull/60)

## Problem

Model `'array'` casts are converted to `Record<string, unknown>` in generated TypeScript types, even when they represent plain arrays.

**Example:**
```php
class Event extends Model
{
    protected $casts = [
        'languages' => 'array',
    ];
}
```

**Current output:**
```ts
languages: Record<string, unknown>
```

**Expected output:**
```ts
languages: unknown[]
```

## Root Cause

In `laravel/surveyor`'s `ModelAnalyzer.php`, the `resolveCast()` method maps all these casts to the same type:

```php
'json', 'encrypted:json', 'encrypted:array', 'encrypted:collection', 'array', 'encrypted:object' 
    => Type::arrayShape(Type::mixed(), Type::mixed()),
```

This produces `Record<string, unknown>` for all of them, but `'array'`, `'encrypted:array'`, and `'encrypted:collection'` represent PHP arrays/lists, not objects.

## Fix

### 1. surveyor (upstream required)

Separate `'array'` cast from `'json'`/`'object'` casts:

```php
'json', 'encrypted:json', 'encrypted:object' => Type::arrayShape(Type::mixed(), Type::mixed()),
'array', 'encrypted:array', 'encrypted:collection' => Type::array([]),
```

**Note:** This change is in `vendor/laravel/surveyor` and needs to be made upstream in the surveyor package.

### 2. wayfinder

Fix empty array type conversion in `TypeScriptConverter::convertArrayResult()`:

```php
if (array_is_list($value)) {
    if (empty($value)) {
        return 'unknown[]'.$nullSuffix;
    }
    // ... rest of logic
}
```

Before: `Type::array([])` → `[]` (invalid TypeScript)
After: `Type::array([])` → `unknown[]` (valid)

## Tests

Added `tests/Unit/Registry/TypeScriptConverterTest.php` with 6 tests:
- `test_array_shape_with_unknown_key_produces_record_type`
- `test_array_shape_with_number_key_produces_array_type`
- `test_array_shape_with_string_key_produces_record_type`
- `test_array_type_produces_array_type`
- `test_json_cast_produces_record_type`
- `test_array_cast_produces_array_type`

All unit tests pass.
