### PR TITLE
Fix plural in wayfinder-development skill description

### DIFF
--- a/resources/boost/skills/wayfinder-development/SKILL.blade.php
+++ b/resources/boost/skills/wayfinder-development/SKILL.blade.php
@@ -1,6 +1,6 @@
 ---
 name: wayfinder-development
-description: "Use this skill for Laravel Wayfinder which auto-generates typed functions for Laravel controllers and routes. ALWAYS use this skill when frontend code needs to call backend routes or controller actions. Trigger when: connecting any React/Vue/Svelte/Inertia frontend to Laravel controllers, routes, building end-to-end features with both frontend and backend, wiring up forms or links to backend endpoints, fixing route-related TypeScript errors, importing from @/actions or @/routes, or running wayfinder:generate. Use Wayfinder route functions instead of hardcoded URLs. Covers: wayfinder() vite plugin, .url()/.get()/.post()/.form(), query params, route model binding, tree-shaking. Do not use for backend-only task"
+description: "Use this skill for Laravel Wayfinder which auto-generates typed functions for Laravel controllers and routes. ALWAYS use this skill when frontend code needs to call backend routes or controller actions. Trigger when: connecting any React/Vue/Svelte/Inertia frontend to Laravel controllers, routes, building end-to-end features with both frontend and backend, wiring up forms or links to backend endpoints, fixing route-related TypeScript errors, importing from @/actions or @/routes, or running wayfinder:generate. Use Wayfinder route functions instead of hardcoded URLs. Covers: wayfinder() vite plugin, .url()/.get()/.post()/.form(), query params, route model binding, tree-shaking. Do not use for backend-only tasks"
 license: MIT
 metadata:
   author: laravel


### PR DESCRIPTION
## Summary
- Updates the `wayfinder-development` Boost skill description from "backend-only task" to "backend-only tasks".

Fixes #280

## Test plan
- [x] Confirmed the frontmatter description string in `resources/boost/skills/wayfinder-development/SKILL.blade.php`
- [ ] Docs/metadata-only change