### PR TITLE
Support Boost 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "laravel/pint": "^1.21",
         "orchestra/testbench": "^11.0|^10.1|^9.0"
     },
+    "conflict": {
+        "laravel/boost": "<2.5.0"
+    },
     "autoload": {
         "psr-4": {
             "Laravel\\Wayfinder\\": "src"

--- a/resources/boost/skills/wayfinder-development/SKILL.blade.php
+++ b/resources/boost/skills/wayfinder-development/SKILL.blade.php
@@ -58,22 +58,22 @@ store.form() // { action: "/posts", method: "post" }
 show(1, { query: { page: 1 } }) // "/posts/1?page=1"
 @endboostsnippet
 
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_LARAVEL) || $assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_REACT) || $assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_VUE) || $assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_SVELTE))
+@if($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_LARAVEL) || $assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT) || $assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_VUE) || $assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_SVELTE))
 ## Wayfinder + Inertia
 
 @if($assist->inertia()->hasFormComponent())
 Use Wayfinder with the `<Form>` component:
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_REACT))
+@if($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT))
 @boostsnippet("Wayfinder Form (React)", "typescript")
 <Form {...store.form()}><input name="title" /></Form>
 @endboostsnippet
 @endif
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_VUE))
+@if($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_VUE))
 @boostsnippet("Wayfinder Form (Vue)", "vue")
 <Form v-bind="store.form()"><input name="title" /></Form>
 @endboostsnippet
 @endif
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_SVELTE))
+@if($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_SVELTE))
 @boostsnippet("Wayfinder Form (Svelte)", "svelte")
 <Form {...store.form()}><input name="title" /></Form>
 @endboostsnippet


### PR DESCRIPTION
Boost 2.5 removed the `Laravel\Roster\Enums\Packages` enum in favour of string constants on `Laravel\Boost\Support\PackageRegistry`, so the Wayfinder skill fails to render and gets skipped during `boost:install`. This updates the four package checks and adds a `laravel/boost` conflict of `<2.5.0`.