### PR TITLE
[next] Fix invalid TypeScript for enums with no cases

### DIFF
--- a/src/Converters/Enums.php
+++ b/src/Converters/Enums.php
@@ -17,12 +17,14 @@ class Enums extends Converter
             $path,
             TypeScript::type(
                 $name,
-                TypeScript::union(
-                    collect($enum->cases)
-                        ->map(fn ($case) => is_string($case) ? "'{$case}'" : (string) $case)
-                        ->values()
-                        ->all(),
-                ),
+                $enum->cases === []
+                    ? 'never'
+                    : TypeScript::union(
+                        collect($enum->cases)
+                            ->map(fn ($case) => is_string($case) ? "'{$case}'" : (string) $case)
+                            ->values()
+                            ->all(),
+                    ),
             )
                 ->referenceClass($enum->name, $enum->filePath())
                 ->export(),
@@ -42,7 +44,9 @@ class Enums extends Converter
             }
         }
 
-        $content[] = '';
+        if ($content !== []) {
+            $content[] = '';
+        }
 
         $obj = TypeScript::object()->inline();
 

--- a/src/Langs/TypeScript/ObjectBuilder.php
+++ b/src/Langs/TypeScript/ObjectBuilder.php
@@ -47,6 +47,10 @@ class ObjectBuilder implements Stringable
 
     public function __toString(): string
     {
+        if ($this->keyValuePairs === []) {
+            return '{}'.($this->satisfies ? ' satisfies '.$this->satisfies : '');
+        }
+
         $object = '{';
         $object .= $this->inline ? ' ' : PHP_EOL;
 

--- a/tests/Enums.test.ts
+++ b/tests/Enums.test.ts
@@ -6,6 +6,7 @@ import {
     Archived,
 } from "../workbench/resources/js/wayfinder/App/Enums/PostStatus";
 import { UnitEnum } from "../workbench/resources/js/wayfinder/App/Enums/UnitEnum";
+import { EmptyEnum } from "../workbench/resources/js/wayfinder/App/Enums/EmptyEnum";
 import type { App } from "../workbench/resources/js/wayfinder/types";
 import {
     ProductStatus,
@@ -84,5 +85,14 @@ describe("Enums", () => {
     test("only exports non-reserved case constants individually", () => {
         expect(used).toBe("used");
         expect(Active).toBe("active");
+    });
+
+    test("enum without cases is an empty object", () => {
+        expect(EmptyEnum).toEqual({});
+        expect(Object.keys(EmptyEnum)).toEqual([]);
+    });
+
+    test("namespaced type for an enum without cases is never", () => {
+        expectTypeOf<App.Enums.EmptyEnum>().toEqualTypeOf<never>();
     });
 });

--- a/workbench/app/Enums/EmptyEnum.php
+++ b/workbench/app/Enums/EmptyEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Enums;
+
+enum EmptyEnum: string
+{
+    //
+}


### PR DESCRIPTION
An enum with no cases generated `export type Foo = ` with nothing after the equals sign, which does not compile. It now generates `never`.

While in there, an empty object literal was rendering as `{  }` inline and, worse, as `{\n,\n}` when not inline, so `ObjectBuilder` now returns `{}` when it has no keys. The enum file also had a stray blank line where the case constants would have gone.

Added a caseless enum to the workbench app and covered both the value and the type in the enum tests.
