### PR TITLE
Add missing strict mode reserved keywords

### DIFF
--- a/src/Langs/TypeScript.php
+++ b/src/Langs/TypeScript.php
@@ -21,6 +21,7 @@ class TypeScript
     protected static $safeImports = [];
 
     public const RESERVED_KEYWORDS = [
+        'await',
         'break',
         'case',
         'catch',
@@ -32,6 +33,7 @@ class TypeScript
         'delete',
         'do',
         'else',
+        'enum',
         'export',
         'extends',
         'false',
@@ -39,12 +41,20 @@ class TypeScript
         'for',
         'function',
         'if',
+        'implements',
         'import',
         'in',
         'instanceof',
+        'interface',
+        'let',
         'new',
         'null',
+        'package',
+        'private',
+        'protected',
+        'public',
         'return',
+        'static',
         'super',
         'switch',
         'this',
@@ -56,6 +66,7 @@ class TypeScript
         'void',
         'while',
         'with',
+        'yield',
     ];
 
     public static function literalUnion(string $type, array|Collection $values): VariableBuilder

--- a/tests/DisallowedMethodNames.test.ts
+++ b/tests/DisallowedMethodNames.test.ts
@@ -6,6 +6,8 @@ import DisallowedMethodNameController, {
 import method2fa from "../workbench/resources/js/wayfinder/routes/2fa";
 import defaultMethod from "../workbench/resources/js/wayfinder/routes/default";
 import disallowed from "../workbench/resources/js/wayfinder/routes/disallowed";
+import publicMethod from "../workbench/resources/js/wayfinder/routes/public";
+import staticMethod from "../workbench/resources/js/wayfinder/routes/static";
 
 test("will append `method` to invalid methods", () => {
     expect(method404.url()).toBe("/disallowed/404");
@@ -29,5 +31,17 @@ test("will properly handle reserved JS words", () => {
     expect(defaultMethod.login.url()).toBe("/disallowed/default");
     expect(DisallowedMethodNameController["default"].url()).toBe(
         "/disallowed/default"
+    );
+});
+
+test("will properly handle strict mode reserved JS words", () => {
+    expect(publicMethod.assets.url()).toBe("/disallowed/public");
+    expect(DisallowedMethodNameController["public"].url()).toBe(
+        "/disallowed/public"
+    );
+
+    expect(staticMethod.files.url()).toBe("/disallowed/static");
+    expect(DisallowedMethodNameController["static"].url()).toBe(
+        "/disallowed/static"
     );
 });

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -94,6 +94,8 @@ Route::get('/disallowed/delete', [DisallowedMethodNameController::class, 'delete
 Route::get('/disallowed/404', [DisallowedMethodNameController::class, '404'])->name('disallowed.404');
 Route::get('/disallowed/2fa', [DisallowedMethodNameController::class, '2fa'])->name('2fa.disallowed');
 Route::get('/disallowed/default', [DisallowedMethodNameController::class, 'default'])->name('default.login');
+Route::get('/disallowed/public', [DisallowedMethodNameController::class, 'public'])->name('public.assets');
+Route::get('/disallowed/static', [DisallowedMethodNameController::class, 'static'])->name('static.files');
 Route::get('/navigation-items/{item}/options', [NavigationItemController::class, 'options']);
 
 Route::get('/anonymous-middleware', [AnonymousMiddlewareController::class, 'show']);


### PR DESCRIPTION
The `RESERVED_KEYWORDS` list was missing everything that JavaScript only reserves in strict mode, plus `await` and `enum`. Since Wayfinder generates ES modules, and modules are always strict, a route method or enum case named `public` produced `export const public = ...`, which is a syntax error.

Adds `await`, `enum`, `implements`, `interface`, `let`, `package`, `private`, `protected`, `public`, `static` and `yield`, so those names now get the usual suffix treatment (`public` becomes `publicMethod`).
