### PR TITLE
Handle nullable route binding columns

### DIFF
--- a/resources/js/wayfinder.ts
+++ b/resources/js/wayfinder.ts
@@ -159,6 +159,17 @@ export const validateParameters = (
     }
 };
 
+export const requireParameter = <T>(
+    value: T,
+    name: string,
+): Exclude<T, null> => {
+    if (value === null) {
+        throw Error(`Parameter "${name}" is null. Unable to generate a URL.`);
+    }
+
+    return value as Exclude<T, null>;
+};
+
 export const setUrlDefaults = (params: UrlDefaults | (() => UrlDefaults)) => {
     urlDefaults = typeof params === "function" ? params : () => params;
 };

--- a/src/Converters/Routes.php
+++ b/src/Converters/Routes.php
@@ -329,5 +329,9 @@ class Routes extends Converter
         if ($routes->first(fn (Route $route) => $route->parameters()->isNotEmpty())) {
             $this->imports[$path]->add($pathKey, 'applyUrlDefaults');
         }
+
+        if ($routes->first(fn (Route $route) => $route->parameters()->first(fn (RouteParameter $parameter) => RouteMethod::hasNullableKey($parameter)))) {
+            $this->imports[$path]->add($pathKey, 'requireParameter');
+        }
     }
 }

--- a/src/Langs/TypeScript/Converters/RouteMethod.php
+++ b/src/Langs/TypeScript/Converters/RouteMethod.php
@@ -4,7 +4,12 @@ namespace Laravel\Wayfinder\Langs\TypeScript\Converters;
 
 use Laravel\Ranger\Components\InertiaResponse;
 use Laravel\Ranger\Components\Route;
+use Laravel\Ranger\Support\RouteParameter;
 use Laravel\Ranger\Support\Verb;
+use Laravel\Surveyor\Types\Contracts\Type as TypeContract;
+use Laravel\Surveyor\Types\NullType;
+use Laravel\Surveyor\Types\Type;
+use Laravel\Surveyor\Types\UnionType;
 use Laravel\Wayfinder\Langs\TypeScript;
 use Laravel\Wayfinder\Langs\TypeScript\ObjectBuilder;
 
@@ -63,6 +68,12 @@ class RouteMethod
             $this->withComponentFormMethod(),
             $this->withForm ? "{$this->name}.form = {$this->name}Form" : '',
         ]));
+    }
+
+    public static function hasNullableKey(RouteParameter $parameter): bool
+    {
+        return $parameter->key !== null
+            && collect($parameter->types)->contains(self::isNullableType(...));
     }
 
     public function computedMethods(): array
@@ -164,12 +175,20 @@ class RouteMethod
         $tuple = TypeScript::tuple();
 
         foreach ($this->route->parameters() as $parameter) {
-            $types = array_map(fn ($type) => TypeScript::fromSurveyorType($type), $parameter->types);
+            $types = array_map(
+                fn ($type) => TypeScript::fromSurveyorType($type),
+                $this->parameterTypes($parameter),
+            );
             $baseTypes = $types;
 
             if ($parameter->key) {
+                // Model objects keep a nullable binding column so they can be
+                // passed straight through; the generated body throws if the
+                // value turns out to be null.
+                $keyTypes = array_map(fn ($type) => TypeScript::fromSurveyorType($type), $parameter->types);
+
                 $paramTypeObject = TypeScript::typeObject();
-                $paramTypeObject->key($parameter->key)->value(TypeScript::union($baseTypes));
+                $paramTypeObject->key($parameter->key)->value(TypeScript::union($keyTypes));
                 $baseTypes[] = (string) $paramTypeObject;
             }
 
@@ -188,6 +207,51 @@ class RouteMethod
         }
 
         return $this->argTypes = $argTypes;
+    }
+
+    /**
+     * A URL can never carry a null parameter, so passing null directly is not
+     * allowed even when the binding column is nullable (e.g. `{post:slug}`
+     * where `slug` is nullable).
+     *
+     * @return array<int, TypeContract>
+     */
+    protected function parameterTypes(RouteParameter $parameter): array
+    {
+        $types = array_values(array_filter(
+            array_map($this->withoutNull(...), $parameter->types),
+            fn (TypeContract $type) => ! $type instanceof NullType,
+        ));
+
+        return $types === [] ? [Type::string(), Type::number()] : $types;
+    }
+
+    protected static function isNullableType(TypeContract $type): bool
+    {
+        if ($type instanceof UnionType) {
+            return collect($type->types)->contains(self::isNullableType(...));
+        }
+
+        return $type->isNullable() || $type instanceof NullType;
+    }
+
+    protected function withoutNull(TypeContract $type): TypeContract
+    {
+        if ($type instanceof UnionType) {
+            $types = array_values(array_filter(
+                array_map($this->withoutNull(...), $type->types),
+                fn (TypeContract $inner) => ! $inner instanceof NullType,
+            ));
+
+            return $types === [] ? Type::null() : Type::union(...$types);
+        }
+
+        if (! $type->isNullable()) {
+            return $type;
+        }
+
+        // The analyzed type is shared with the model converters, so copy before clearing nullability.
+        return (clone $type)->nullable(false);
     }
 
     protected function definition(): string
@@ -230,10 +294,18 @@ class RouteMethod
                 }
                 TS;
 
-                if ($this->route->parameters()->first()->key) {
+                $parameter = $this->route->parameters()->first();
+
+                if ($parameter->key) {
+                    $keyValue = "{$this->argsParam}.{$parameter->key}";
+
+                    if (self::hasNullableKey($parameter)) {
+                        $keyValue = sprintf('requireParameter(%s, "%s")', $keyValue, $parameter->name);
+                    }
+
                     $body[] = <<<TS
-                    if (typeof {$this->argsParam} === "object" && !Array.isArray({$this->argsParam}) && "{$this->route->parameters()->first()->key}" in {$this->argsParam}) {
-                        {$this->argsParam} = { {$this->route->parameters()->first()->name}: {$this->argsParam}.{$this->route->parameters()->first()->key} }
+                    if (typeof {$this->argsParam} === "object" && !Array.isArray({$this->argsParam}) && "{$parameter->key}" in {$this->argsParam}) {
+                        {$this->argsParam} = { {$parameter->name}: {$keyValue} }
                     }
                     TS;
                 }
@@ -287,6 +359,10 @@ class RouteMethod
 
                 if ($parameter->default !== null) {
                     $val = sprintf('(%s) ?? "%s"', $val, $parameter->default);
+                }
+
+                if (self::hasNullableKey($parameter)) {
+                    $val = sprintf('requireParameter(%s, "%s")', $val, $parameter->name);
                 }
 
                 $keyVal->value($val);

--- a/tests/ModelBindingController.test.ts
+++ b/tests/ModelBindingController.test.ts
@@ -1,8 +1,55 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import { expect, test } from "vitest";
-import { show } from "../workbench/resources/js/wayfinder/App/Http/Controllers/ModelBindingController";
+import {
+    nullableBinding,
+    show,
+} from "../workbench/resources/js/wayfinder/App/Http/Controllers/ModelBindingController";
 
 test("will detect model binding", () => {
     expect(show.url(1)).toBe("/users/1");
     expect(show.url({ user: 1 })).toBe("/users/1");
     expect(show.url([1])).toBe("/users/1");
+});
+
+test("will generate urls for a nullable binding column", () => {
+    const token = "547a7452-9dc5-4f64-a275-d646dea6ebcf";
+
+    expect(nullableBinding.url(token)).toBe(`/users/by-token/${token}`);
+    expect(nullableBinding.url({ user: token })).toBe(
+        `/users/by-token/${token}`,
+    );
+    expect(nullableBinding.url([token])).toBe(`/users/by-token/${token}`);
+    expect(nullableBinding.url({ remember_token: token })).toBe(
+        `/users/by-token/${token}`,
+    );
+});
+
+test("will throw when a nullable binding column is null", () => {
+    expect(() => nullableBinding.url({ remember_token: null })).toThrowError(
+        'Parameter "user" is null. Unable to generate a URL.',
+    );
+
+    expect(() =>
+        nullableBinding.url({ user: { remember_token: null } }),
+    ).toThrowError('Parameter "user" is null. Unable to generate a URL.');
+
+    expect(() =>
+        nullableBinding.url([{ remember_token: null }]),
+    ).toThrowError('Parameter "user" is null. Unable to generate a URL.');
+});
+
+test("will accept an object with a nullable binding column, but not a bare null", () => {
+    const source = readFileSync(
+        join(
+            __dirname,
+            "../workbench/resources/js/wayfinder/App/Http/Controllers/ModelBindingController.ts",
+        ),
+        "utf-8",
+    );
+
+    expect(source).toContain(
+        "args: { user: string | { remember_token: string | null } }",
+    );
+    expect(source).not.toContain("user: string | null");
 });

--- a/workbench/app/Http/Controllers/ModelBindingController.php
+++ b/workbench/app/Http/Controllers/ModelBindingController.php
@@ -10,4 +10,9 @@ class ModelBindingController
     {
         //
     }
+
+    public function nullableBinding(User $user)
+    {
+        //
+    }
 }

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -68,6 +68,7 @@ Route::post('/optional/{parameter?}', [OptionalController::class, 'optional'])->
 Route::post('/many-optional/{one?}/{two?}/{three?}', [OptionalController::class, 'manyOptional']);
 
 Route::get('/users/{user}', [ModelBindingController::class, 'show']);
+Route::get('/users/by-token/{user:remember_token}', [ModelBindingController::class, 'nullableBinding']);
 
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}', [UrlDefaultsController::class, 'onlyDefaults']);
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}/also/{timezone}', [UrlDefaultsController::class, 'mixedDefaults']);


### PR DESCRIPTION
A model whose binding column is nullable (say `{post:slug}` where `slug` is nullable) produced arguments typed `string | null`, and the generated `url()` method then failed to compile: `applyUrlDefaults()` only takes `UrlDefaults | undefined`, and `.toString()` was called on a value that might be null.

Null is now dropped from the scalar argument forms, since a URL can never carry a null segment, so passing null directly is a type error. Objects keep the nullable column so a model can still be passed straight through, and the generated body sends the value through a new `requireParameter()` helper that throws if it really is null. The check runs after the `??` fallback, so URL defaults still win.
