### PR TITLE
Reuse file modification times during generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
         "laravel/ranger": "^0.2.4",
-        "laravel/surveyor": "^0.2.1",
+        "laravel/surveyor": "^0.2.7",
         "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -138,8 +138,6 @@ class GenerateCommand extends Command
         $this->ranger->walk();
 
         $this->writeFiles();
-
-        AnalyzedCache::freezeFileTimes(false);
     }
 
     protected function getBasePaths(): array

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -59,6 +59,7 @@ class GenerateCommand extends Command
         Enums $enumConverter,
         Routes $routesConverter,
     ) {
+        AnalyzedCache::freezeFileTimes();
         AnalyzedCache::setCacheDirectory($this->config->get('wayfinder.cache.directory'));
 
         if ($this->option('fresh') || ! $this->config->get('wayfinder.cache.enabled')) {
@@ -137,6 +138,8 @@ class GenerateCommand extends Command
         $this->ranger->walk();
 
         $this->writeFiles();
+
+        AnalyzedCache::freezeFileTimes(false);
     }
 
     protected function getBasePaths(): array


### PR DESCRIPTION
Bumps `laravel/surveyor` to `^0.2.7` and turns on its new `AnalyzedCache::freezeFileTimes()` for the duration of `wayfinder:generate`.

The analyzed cache checks a file's modification time on every lookup, and PHP only caches the most recently stat'ed file, so interleaved lookups all hit the OS. Since a one-shot command can't have its files change underneath it, we look each one up once and reuse it, then unfreeze when the command finishes.

On the workbench (55 PHP files) a warm run drops from 23,681 stat calls to 806, and a cold run from 14,858 to 806. Generated output is unchanged.
