### PR TITLE
Key routes that share a URI by verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,26 @@ import { index } from "@/actions/App/Http/Controllers/ClientPaymentsController";
 index["/clients/{client}/payments"]({ client: 1 });
 ```
 
+If two of those routes share a URI and differ only by verb, each key is prefixed with the verb, so you can still pick the one you want:
+
+```php
+Route::get('/exports/{report}', ExportController::class)
+    ->name('exports.show');
+
+Route::post('/exports/{report}', ExportController::class)
+    ->middleware('throttle:5,1')
+    ->name('exports.run');
+```
+
+```ts
+import ExportController from "@/actions/App/Http/Controllers/ExportController";
+
+ExportController["get /exports/{report}"]({ report: 1 });
+ExportController["post /exports/{report}"]({ report: 1 });
+```
+
+A route that answers to more than one verb joins them with `|`, as in `ExportController["put|patch /exports/{report}"]`. Exports whose URIs are already unique keep the plain URI keys shown above.
+
 In most cases it is easier to import the route by name from your generated `routes/` directory instead:
 
 ```ts

--- a/resources/multi-method.blade.ts
+++ b/resources/multi-method.blade.ts
@@ -9,11 +9,12 @@
 
 /**
 * Multiple routes resolve to {!! $controller !!}::{!! $original_method !!}, so this export is a
-* dictionary keyed by URI rather than a callable. Call a specific route with `{!! $method !!}['<uri>'](...)`,
-* or import the route by name from your generated `routes/` directory.
+* dictionary keyed by URI rather than a callable, with the verbs prefixed where two routes share a URI.
+* Call a specific route with `{!! $method !!}['<key>'](...)`, or import the route by name from your
+* generated `routes/` directory.
 */
 {!! when($shouldExport, 'export ') !!}const {!! $method !!} = {
 @foreach ($routes as $route)
-    {!! $route['uri'] !!}: {!! $route['tempMethod'] !!},
+    {!! $route['key'] !!}: {!! $route['tempMethod'] !!},
 @endforeach
 }{{PHP_EOL}}

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -270,22 +270,20 @@ class GenerateCommand extends Command
             'shouldExport' => ! $isInvokable,
             'withForm' => $this->option('with-form') ?? false,
             ...$this->safeParamNames($method),
-            'routes' => $routes->map(fn ($r) => [
-                'method' => $r->jsMethod(),
-                'tempMethod' => $r->jsMethod().hash('xxh128', $this->routeKey($r, $duplicateUris)),
-                'parameters' => $r->parameters(),
-                'verbs' => $r->verbs(),
-                'uri' => $r->uri(),
-                'key' => $this->routeKey($r, $duplicateUris),
-            ]),
-        ])->render());
-    }
+            'routes' => $routes->map(function (Route $r) use ($duplicateUris) {
+                $uri = $r->uri();
+                $key = $duplicateUris->contains($uri) ? $r->verbPrefixedUri() : $uri;
 
-    private function routeKey(Route $route, Collection $duplicateUris): string
-    {
-        return $duplicateUris->contains($route->uri())
-            ? $route->uriWithVerbs()
-            : $route->uri();
+                return [
+                    'method' => $r->jsMethod(),
+                    'tempMethod' => $r->jsMethod().hash('xxh128', $key),
+                    'parameters' => $r->parameters(),
+                    'verbs' => $r->verbs(),
+                    'uri' => $uri,
+                    'key' => $key,
+                ];
+            }),
+        ])->render());
     }
 
     private function writeControllerMethodExport(Route $route, string $path): void

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -258,6 +258,8 @@ class GenerateCommand extends Command
         $isInvokable = $routes->first()->hasInvokableController();
         $method = $routes->first()->jsMethod();
 
+        $duplicateUris = $routes->duplicates(fn (Route $route) => $route->uri());
+
         $this->appendContent($path, $this->view->make('wayfinder::multi-method', [
             'method' => $method,
             'original_method' => $routes->first()->originalJsMethod(),
@@ -270,12 +272,20 @@ class GenerateCommand extends Command
             ...$this->safeParamNames($method),
             'routes' => $routes->map(fn ($r) => [
                 'method' => $r->jsMethod(),
-                'tempMethod' => $r->jsMethod().hash('xxh128', $r->uri()),
+                'tempMethod' => $r->jsMethod().hash('xxh128', $this->routeKey($r, $duplicateUris)),
                 'parameters' => $r->parameters(),
                 'verbs' => $r->verbs(),
                 'uri' => $r->uri(),
+                'key' => $this->routeKey($r, $duplicateUris),
             ]),
         ])->render());
+    }
+
+    private function routeKey(Route $route, Collection $duplicateUris): string
+    {
+        return $duplicateUris->contains($route->uri())
+            ? $route->uriWithVerbs()
+            : $route->uri();
     }
 
     private function writeControllerMethodExport(Route $route, string $path): void

--- a/src/Route.php
+++ b/src/Route.php
@@ -96,7 +96,7 @@ class Route
         return Js::from($this->rawUri(), JSON_UNESCAPED_SLASHES)->toHtml();
     }
 
-    public function uriWithVerbs(): string
+    public function verbPrefixedUri(): string
     {
         return Js::from($this->keyVerbs()->implode('|').' '.$this->rawUri(), JSON_UNESCAPED_SLASHES)->toHtml();
     }

--- a/src/Route.php
+++ b/src/Route.php
@@ -93,27 +93,12 @@ class Route
 
     public function uri(): string
     {
-        $defaultParams = $this->paramDefaults->mapWithKeys(fn ($value, $key) => ["{{$key}}" => "{{$key}?}"]);
+        return Js::from($this->rawUri(), JSON_UNESCAPED_SLASHES)->toHtml();
+    }
 
-        $uri = str($this->base->uri)->start('/')->toString();
-
-        if (($basePath = $this->basePath()) !== '') {
-            $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
-        }
-
-        if (($domain = $this->domain()) !== null) {
-            $uri = ($this->scheme() ?? '//').$domain.$uri;
-        }
-
-        $uri = str($uri)
-            ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
-            ->toString();
-
-        if ($uri !== '/') {
-            $uri = rtrim($uri, '/');
-        }
-
-        return Js::from($uri, JSON_UNESCAPED_SLASHES)->toHtml();
+    public function uriWithVerbs(): string
+    {
+        return Js::from($this->keyVerbs()->implode('|').' '.$this->rawUri(), JSON_UNESCAPED_SLASHES)->toHtml();
     }
 
     public function scheme(): ?string
@@ -211,6 +196,38 @@ class Route
         }
 
         return 0;
+    }
+
+    private function keyVerbs(): Collection
+    {
+        $verbs = $this->verbs()->pluck('actual');
+
+        return $verbs->contains('get') ? $verbs->reject(fn ($verb) => $verb === 'head') : $verbs;
+    }
+
+    private function rawUri(): string
+    {
+        $defaultParams = $this->paramDefaults->mapWithKeys(fn ($value, $key) => ["{{$key}}" => "{{$key}?}"]);
+
+        $uri = str($this->base->uri)->start('/')->toString();
+
+        if (($basePath = $this->basePath()) !== '') {
+            $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
+        }
+
+        if (($domain = $this->domain()) !== null) {
+            $uri = ($this->scheme() ?? '//').$domain.$uri;
+        }
+
+        $uri = str($uri)
+            ->replace($defaultParams->keys()->toArray(), $defaultParams->values()->toArray())
+            ->toString();
+
+        if ($uri !== '/') {
+            $uri = rtrim($uri, '/');
+        }
+
+        return $uri;
     }
 
     private function finalJsMethod(string $method): string

--- a/tests/SharedUriController.test.ts
+++ b/tests/SharedUriController.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "vitest";
+import SharedUriController from "../workbench/resources/js/actions/App/Http/Controllers/SharedUriController";
+
+it("keys routes sharing a URI by verb", () => {
+    expect(SharedUriController["get /shared-uri/{name}"].url("test")).toBe(
+        "/shared-uri/test",
+    );
+    expect(SharedUriController["get /shared-uri/{name}"]("test")).toEqual({
+        url: "/shared-uri/test",
+        method: "get",
+    });
+
+    expect(SharedUriController["post /shared-uri/{name}"].url("test")).toBe(
+        "/shared-uri/test",
+    );
+    expect(SharedUriController["post /shared-uri/{name}"]("test")).toEqual({
+        url: "/shared-uri/test",
+        method: "post",
+    });
+
+    expect(SharedUriController["put|patch /shared-uri/{name}"].url("test")).toBe(
+        "/shared-uri/test",
+    );
+    expect(SharedUriController["put|patch /shared-uri/{name}"]("test")).toEqual({
+        url: "/shared-uri/test",
+        method: "put",
+    });
+});

--- a/workbench/app/Http/Controllers/SharedUriController.php
+++ b/workbench/app/Http/Controllers/SharedUriController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class SharedUriController
+{
+    public function __invoke()
+    {
+        //
+    }
+}

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Nested\NestedController;
 use App\Http\Controllers\OptionalController;
 use App\Http\Controllers\ParameterNameController;
 use App\Http\Controllers\PostController;
+use App\Http\Controllers\SharedUriController;
 use App\Http\Controllers\TwoRoutesSameActionController;
 use App\Http\Controllers\UrlDefaultsController;
 use App\Http\Middleware\UrlDefaultsMiddleware;
@@ -79,6 +80,10 @@ Route::get('/prism/chat', [PrismChatController::class, 'index']);
 
 Route::get('/two-routes-one-action-1', [TwoRoutesSameActionController::class, 'same']);
 Route::get('/two-routes-one-action-2', [TwoRoutesSameActionController::class, 'same']);
+
+Route::get('/shared-uri/{name}', SharedUriController::class);
+Route::post('/shared-uri/{name}', SharedUriController::class);
+Route::match(['put', 'patch'], '/shared-uri/{name}', SharedUriController::class);
 
 Route::get('/disallowed/delete', [DisallowedMethodNameController::class, 'delete']);
 Route::get('/disallowed/404', [DisallowedMethodNameController::class, '404'])->name('disallowed.404');


### PR DESCRIPTION
When two routes point at the same invokable controller on the same URI and differ only by verb, the generated action file doesn't compile. Both routes land in the same `__invoke` group, and every entry in the dictionary Wayfinder writes is keyed by URI alone, so the key is written twice and the const it points at (named from a hash of the URI) is declared twice as well.

```php
Route::post('/actions/{name}', ActionController::class)->name('actions.run');
Route::get('/actions/{name}', ActionController::class)->name('actions.show');
```

Entries whose URI is shared with another route in the same export are now keyed by verb and URI, so the example above generates `ActionController['post /actions/{name}']` and `ActionController['get /actions/{name}']`. Exports where the URIs are already unique keep the keys they have today, and the caller still picks the route explicitly rather than getting a default, which was the concern in #187.

Closes #302