### PR TITLE
Fix: Generate `--fresh` still caches

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -62,9 +62,13 @@ class GenerateCommand extends Command
         AnalyzedCache::freezeFileTimes();
         AnalyzedCache::setCacheDirectory($this->config->get('wayfinder.cache.directory'));
 
-        if ($this->option('fresh') || ! $this->config->get('wayfinder.cache.enabled')) {
+        $cacheEnabled = $this->config->get('wayfinder.cache.enabled');
+
+        if ($this->option('fresh') || ! $cacheEnabled) {
             AnalyzedCache::clear();
-        } else {
+        }
+
+        if ($cacheEnabled) {
             AnalyzedCache::enable();
         }
 

--- a/tests/Feature/GenerateCommandTest.php
+++ b/tests/Feature/GenerateCommandTest.php
@@ -47,8 +47,7 @@ class GenerateCommandTest extends TestCase
             '--path='.$this->tempPath,
             '--app-path='.join_paths($this->rootPath, 'workbench', 'app'),
             '--base-path='.join_paths($this->rootPath, 'workbench'),
-            '--fresh',
-        ], $this->rootPath);
+        ], $this->rootPath, ['WAYFINDER_CACHE_ENABLED' => 'false']);
 
         $process->setTimeout(60);
         $process->run();


### PR DESCRIPTION
Previously, `--fresh` also disabled the cache, so you paid the cold cost twice. Now cache will be written (if it is enabled) on generated fresh.