### PR TITLE
Stop freezing forceRootUrl domains into generated URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /package-lock.json
 /vendor
 /workbench/resources/js
+/workbench/resources/js-forced-root
 .idea
 .vscode

--- a/build.ts
+++ b/build.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 
 const testbenchDir = path.join(__dirname, "vendor", "bin", "testbench");
 
-const artisan = (command: string): void => console.error(execSync(`${testbenchDir} ${command}`).toString('utf8'))
+const artisan = (command: string, env: NodeJS.ProcessEnv = {}): void =>
+    console.error(execSync(`${testbenchDir} ${command}`, { env: { ...process.env, ...env } }).toString('utf8'))
 
 export function setup(): void {
     try {
@@ -12,6 +13,10 @@ export function setup(): void {
             : artisan('route:clear')
 
         artisan('wayfinder:generate --path=workbench/resources/js --with-form')
+
+        artisan('wayfinder:generate --path=workbench/resources/js-forced-root --with-form', {
+            WAYFINDER_FORCE_ROOT_URL: 'https://tenant-a.example.test:8443',
+        })
     } catch (error) {
         console.error(`Wayfinder build error\n----------${error.output}\n----------`);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,10 @@ export default tseslint.config(
     js.configs.recommended,
     ...tseslint.configs.recommended,
     {
-        files: ["workbench/resources/js/**/*.{ts,tsx}"],
+        files: [
+            "workbench/resources/js/**/*.{ts,tsx}",
+            "workbench/resources/js-forced-root/**/*.{ts,tsx}",
+        ],
         rules: {
             "no-duplicate-imports": "error",
         },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "scripts": {
         "test": "vendor/bin/phpunit && vitest run && npm run lint && npm run test-routes-cached && npm run lint && npm run tsc",
         "test-routes-cached": "WAYFINDER_CACHE_ROUTES=1 vitest run",
-        "lint": "eslint ./workbench/resources/js --ext .ts,.tsx",
-        "lint:fix": "eslint ./workbench/resources/js --ext .ts,.tsx --fix",
+        "lint": "eslint ./workbench/resources/js ./workbench/resources/js-forced-root --ext .ts,.tsx",
+        "lint:fix": "eslint ./workbench/resources/js ./workbench/resources/js-forced-root --ext .ts,.tsx --fix",
         "format": "npx --yes prettier --write \"resources/js/**/*.{ts,js,json}\"",
         "tsc": "tsc --noEmit"
     },

--- a/resources/method.blade.ts
+++ b/resources/method.blade.ts
@@ -35,9 +35,9 @@
     {!! $args !!} = applyUrlDefaults({!! $args !!})
 @endif
 
-@if ($parameters->where('optional')->isNotEmpty())
+@if ($parameters->filter->canBeMissingSegment()->isNotEmpty())
     validateParameters({!! $args !!}, [
-    @foreach ($parameters->where('optional') as $parameter)
+    @foreach ($parameters->filter->canBeMissingSegment() as $parameter)
         "{!! $parameter->name !!}",
     @endforeach
     ])
@@ -49,9 +49,9 @@
         @if ($parameter->key)
             {!! $parameter->name !!}: {!! when($parameter->default !== null, '(') !!}typeof {!! $args !!}{!! when($parameters->every->optional, '?') !!}.{!! $parameter->name !!} === 'object'
                 ? {!! $args !!}.{!! $parameter->name !!}.{!! $parameter->key ?? 'id' !!}
-                : {!! $args !!}{!! when($parameters->every->optional, '?') !!}.{!! $parameter->name !!}{!! when($parameter->default !== null, ') ?? ') !!}@if ($parameter->default !== null)@js($parameter->default)@endif,
+                : {!! $args !!}{!! when($parameters->every->optional, '?') !!}.{!! $parameter->name !!}{!! when($parameter->default !== null, ') ?? ') !!}@if ($parameter->default !== null){!! \Illuminate\Support\Js::from($parameter->default, JSON_UNESCAPED_SLASHES)->toHtml() !!}@endif,
         @else
-            {!! $parameter->name !!}: {!! $args !!}{!! when($parameters->every->optional, '?') !!}.{!! $parameter->name !!}{!! when($parameter->default !== null, ' ?? ') !!}@if ($parameter->default !== null)@js($parameter->default)@endif,
+            {!! $parameter->name !!}: {!! $args !!}{!! when($parameters->every->optional, '?') !!}.{!! $parameter->name !!}{!! when($parameter->default !== null, ' ?? ') !!}@if ($parameter->default !== null){!! \Illuminate\Support\Js::from($parameter->default, JSON_UNESCAPED_SLASHES)->toHtml() !!}@endif,
         @endif
     @endforeach
     }

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -323,7 +323,7 @@ class GenerateCommand extends Command
             $imports[] = 'applyUrlDefaults';
         }
 
-        if ($routes->contains(fn (Route $route) => $route->parameters()->contains(fn (Parameter $parameter) => $parameter->optional))) {
+        if ($routes->contains(fn (Route $route) => $route->parameters()->contains(fn (Parameter $parameter) => $parameter->canBeMissingSegment()))) {
             $imports[] = 'validateParameters';
         }
 

--- a/src/Parameter.php
+++ b/src/Parameter.php
@@ -78,4 +78,15 @@ class Parameter
     {
         return TypeScript::safeMethod($this->name, 'Param');
     }
+
+    /**
+     * Whether this parameter can be absent from the generated URL - i.e. whether omitting it
+     * leaves a real gap in the path. A parameter with a non-empty default always resolves to
+     * that value via `?? default`, so it can never actually be missing; one whose default is
+     * empty (or absent) can be, and must still participate in the "no holes" runtime check.
+     */
+    public function canBeMissingSegment(): bool
+    {
+        return $this->optional && ($this->default === null || $this->default === '');
+    }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -14,6 +14,8 @@ use ReflectionClass;
 
 class Route
 {
+    private const ORIGIN_PARAMETER_NAME = 'wayfinderOrigin';
+
     private ?array $parsedRoot = null;
 
     public function __construct(
@@ -77,13 +79,19 @@ class Route
 
         $signatureParams = collect($this->base->signatureParameters(UrlRoutable::class));
 
-        return collect($this->base->parameterNames())->map(fn ($name) => new Parameter(
+        $parameters = collect($this->base->parameterNames())->map(fn ($name) => new Parameter(
             $name,
             $optionalParameters->has($name) || $this->paramDefaults->has($name),
             $this->base->bindingFieldFor($name),
             $this->paramDefaults->get($name),
             $signatureParams->first(fn ($p) => Str::snake($p->getName()) === Str::snake($name)),
         ));
+
+        if ($origin = $this->originParameter()) {
+            $parameters->push($origin);
+        }
+
+        return $parameters;
     }
 
     public function verbs(): Collection
@@ -101,8 +109,10 @@ class Route
             $uri = str($basePath)->finish('/')->append(ltrim($uri, '/'))->toString();
         }
 
-        if (($domain = $this->domain()) !== null) {
-            $uri = ($this->scheme() ?? '//').$domain.$uri;
+        if ($this->domain() !== null) {
+            $uri = $this->hasExplicitDomain()
+                ? ($this->scheme() ?? '//').$this->domain().$uri
+                : $this->originParameter()->placeholder.$uri;
         }
 
         $uri = str($uri)
@@ -154,6 +164,33 @@ class Route
         }
 
         return null;
+    }
+
+    public function hasExplicitDomain(): bool
+    {
+        return (bool) $this->base->getDomain();
+    }
+
+    /**
+     * A domain baked in only via URL::forceRootUrl() (not an explicit
+     * Route::domain() binding) reflects the environment the routes were
+     * generated in, not a real per-route domain constraint. Rather than
+     * freezing that value into the generated URL, expose it as an optional,
+     * runtime-overridable parameter with the generate-time value as its
+     * default - the same mechanism already used for other URL defaults.
+     */
+    private function originParameter(): ?Parameter
+    {
+        if ($this->hasExplicitDomain() || ($domain = $this->domain()) === null) {
+            return null;
+        }
+
+        return new Parameter(
+            self::ORIGIN_PARAMETER_NAME,
+            true,
+            null,
+            ($this->scheme() ?? '//').$domain,
+        );
     }
 
     public function name(): ?string

--- a/tests/ForceRootUrlOrigin.test.ts
+++ b/tests/ForceRootUrlOrigin.test.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "vitest";
+import { manyOptional } from "../workbench/resources/js-forced-root/actions/App/Http/Controllers/OptionalController";
+import { index } from "../workbench/resources/js-forced-root/actions/App/Http/Controllers/PostController";
+import { setUrlDefaults } from "../workbench/resources/js-forced-root/wayfinder";
+
+const testbench = path.join(__dirname, "../vendor/bin/testbench");
+
+const generateWithForcedRoot = (forcedRoot: string, outputPath: string) => {
+    rmSync(outputPath, { recursive: true, force: true });
+
+    execFileSync(
+        testbench,
+        ["wayfinder:generate", `--path=${outputPath}`, "--with-form"],
+        {
+            env: {
+                ...process.env,
+                WAYFINDER_FORCE_ROOT_URL: forcedRoot,
+            },
+        },
+    );
+};
+
+test("does not freeze a forceRootUrl-derived domain into the generated URL", () => {
+    const outputPath = "/tmp/wayfinder-force-root-origin";
+
+    generateWithForcedRoot("https://tenant-a.example.test:8443", outputPath);
+
+    const contents = readFileSync(
+        path.join(outputPath, "actions/App/Http/Controllers/PostController.ts"),
+        "utf8",
+    );
+
+    expect(contents).toContain("url: '{wayfinderOrigin?}/posts'");
+    expect(contents).not.toContain(
+        "url: 'https://tenant-a.example.test:8443/posts'",
+    );
+});
+
+test("still bakes an explicit Route::domain() host literally even when forceRootUrl is active", () => {
+    const outputPath = "/tmp/wayfinder-force-root-origin-explicit-domain";
+
+    generateWithForcedRoot("https://tenant-a.example.test:8443", outputPath);
+
+    const contents = readFileSync(
+        path.join(
+            outputPath,
+            "actions/App/Http/Controllers/DomainController.ts",
+        ),
+        "utf8",
+    );
+
+    // The explicit domain host ("example.test") is untouched by forceRootUrl.
+    // (Scheme forcing is a separate, pre-existing behavior this fix doesn't touch.)
+    expect(contents).toContain("/fixed-domain/{param}'");
+    expect(contents).not.toContain("wayfinderOrigin");
+    expect(contents).toMatch(/url: '[a-z]+:\/\/example\.test\/fixed-domain/);
+});
+
+test("falls back to the generate-time origin when no runtime override is supplied", () => {
+    expect(index.url()).toBe("https://tenant-a.example.test:8443/posts");
+});
+
+test("can be overridden at runtime via setUrlDefaults, like any other url default", () => {
+    setUrlDefaults({ wayfinderOrigin: "https://tenant-b.example.test" });
+
+    expect(index.url()).toBe("https://tenant-b.example.test/posts");
+
+    setUrlDefaults({});
+});
+
+test("does not throw when only the origin is overridden and a route's own optional path parameters are left unset", () => {
+    expect(() =>
+        manyOptional.url({ wayfinderOrigin: "https://tenant-b.example.test" }),
+    ).not.toThrow();
+
+    expect(
+        manyOptional.url({ wayfinderOrigin: "https://tenant-b.example.test" }),
+    ).toBe("https://tenant-b.example.test/many-optional");
+});
+
+test("does not throw when the origin is overridden alongside a route's own leading optional path parameter", () => {
+    expect(
+        manyOptional.url({
+            one: "1",
+            wayfinderOrigin: "https://tenant-b.example.test",
+        }),
+    ).toBe("https://tenant-b.example.test/many-optional/1");
+});
+
+test("still throws when a route's own optional path parameter is skipped over, origin aside", () => {
+    expect(() => manyOptional.url({ two: "2" })).toThrow();
+});

--- a/tests/OptionalController.test.ts
+++ b/tests/OptionalController.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, test } from "vitest";
 import {
+    emptyDefault,
     manyOptional,
     optional,
 } from "../workbench/resources/js/actions/App/Http/Controllers/OptionalController";
@@ -42,5 +43,21 @@ describe("manyOptional", async () => {
         expect(manyOptional.definition.url).toBe(
             "/many-optional/{one?}/{two?}/{three?}",
         );
+    });
+});
+
+describe("emptyDefault", async () => {
+    it("throws rather than silently producing a hole when an empty-default parameter is skipped ahead of a real optional one", () => {
+        expect(() => emptyDefault.url({ slug: "x" })).toThrow();
+    });
+
+    it("still produces a double slash when every optional segment (including the empty-default one) is omitted, a pre-existing limitation of trailing-optional URL building", () => {
+        expect(emptyDefault.url()).toBe("/empty-default//thing");
+    });
+
+    test("url", () => {
+        expect(
+            emptyDefault.url({ emptyUrlDefault: "acme", slug: "x" }),
+        ).toBe("/empty-default/acme/thing/x");
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     },
     "include": [
         "workbench/resources/js/**/*.ts",
+        "workbench/resources/js-forced-root/**/*.ts",
         "resources/js/**/*.ts",
         "tests/**/*.ts"
     ],

--- a/workbench/app/Http/Controllers/OptionalController.php
+++ b/workbench/app/Http/Controllers/OptionalController.php
@@ -13,4 +13,9 @@ class OptionalController
     {
         //
     }
+
+    public function emptyDefault()
+    {
+        //
+    }
 }

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -24,6 +24,10 @@ class WorkbenchServiceProvider extends ServiceProvider
 
         URL::defaults([
             'defaultDomain' => 'tim.macdonald',
+            // Non-scalar URL::defaults() values are coerced to '' at generate time.
+            'emptyUrlDefault' => new class
+            {
+            },
         ]);
     }
 
@@ -32,6 +36,8 @@ class WorkbenchServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if ($root = env('WAYFINDER_FORCE_ROOT_URL')) {
+            URL::forceRootUrl($root);
+        }
     }
 }

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -53,6 +53,7 @@ Route::get('/', function () {
 
 Route::post('/optional/{parameter?}', [OptionalController::class, 'optional'])->name('optional');
 Route::post('/many-optional/{one?}/{two?}/{three?}', [OptionalController::class, 'manyOptional']);
+Route::get('/empty-default/{emptyUrlDefault}/thing/{slug?}', [OptionalController::class, 'emptyDefault']);
 
 Route::get('/users/{user}', [ModelBindingController::class, 'show']);
 Route::get('/audit-entries/{audit_entry}', [AuditEntryController::class, 'show']);


### PR DESCRIPTION
## Summary

- When a route's domain comes only from `URL::forceRootUrl()` (not an explicit `Route::domain()` binding), it's now generated as an optional `wayfinderOrigin` URL parameter defaulting to the generate-time origin, instead of being baked literally into the generated URL string. Routes with an explicit `Route::domain()` are untouched. Callers can override the origin at runtime via `setUrlDefaults({ wayfinderOrigin: ... })`, same as any other URL default.
- Fixes a validator-ordering bug (found via TDD) where the runtime "no missing optional parameters" check threw on any route that had both the new synthetic origin parameter and its own optional path parameters — extracted the "can this parameter actually be missing" rule into `Parameter::canBeMissingSegment()` as a single source of truth shared by the Blade template and the import-gating logic.
- Fixes a related gap where a parameter with an empty-string (rather than null) generate-time default could silently produce a hole in the path instead of failing loudly.
- Adds the `workbench/resources/js-forced-root` fixture tree (used to test this feature) to ESLint and `tsconfig.json` coverage — it had been silently excluded from both.

## Test plan

- [x] `vendor/bin/phpunit`
- [x] `npx vitest run` (includes new `tests/ForceRootUrlOrigin.test.ts` and new `emptyDefault` cases in `tests/OptionalController.test.ts`)
- [x] `WAYFINDER_CACHE_ROUTES=1 npx vitest run`
- [x] `npm run lint` (now covers `js-forced-root` too)
- [x] `npm run tsc`