### PR TITLE
Escape quotes and other special characters in generated values

### DIFF
--- a/src/Converters/BroadcastChannels.php
+++ b/src/Converters/BroadcastChannels.php
@@ -22,13 +22,7 @@ class BroadcastChannels extends Converter
         }
 
         $types = $channels->map(
-            fn (BroadcastChannel $channel) => TypeScript::backtick(
-                preg_replace(
-                    self::PARAM_PATTERN,
-                    TypeScript::templateString(TypeScript::union(['string', 'number'])),
-                    $channel->name,
-                ),
-            ),
+            fn (BroadcastChannel $channel) => $this->channelType($channel->name),
         );
 
         $js = $channels
@@ -39,7 +33,7 @@ class BroadcastChannels extends Converter
             ->map($this->channelChain(...));
 
         $content = [
-            (string) TypeScript::literalUnion('BroadcastChannel', $types)->export(),
+            (string) TypeScript::type('BroadcastChannel', TypeScript::union($types->values()->all()))->export(),
             (string) TypeScript::constant(
                 'BroadcastChannels',
                 TypeScript::objectWithOnlyKeys($js),
@@ -51,13 +45,7 @@ class BroadcastChannels extends Converter
 
     protected function toConstData(BroadcastChannel $channel): array
     {
-        $returnType = TypeScript::backtick(
-            preg_replace(
-                self::PARAM_PATTERN,
-                TypeScript::templateString(TypeScript::union(['string', 'number'])),
-                $channel->name,
-            ),
-        );
+        $returnType = $this->channelType($channel->name);
 
         $parts = collect(explode('.', $channel->name));
 
@@ -152,8 +140,19 @@ class BroadcastChannels extends Converter
         return collect($params)->map(fn ($p) => "{$p}: string | number")->implode(', ');
     }
 
+    protected function channelType(string $name): string
+    {
+        return TypeScript::backtick(
+            preg_replace(
+                self::PARAM_PATTERN,
+                TypeScript::templateString(TypeScript::union(['string', 'number'])),
+                TypeScript::escapeTemplateLiteral($name),
+            ),
+        );
+    }
+
     protected function convertTemplateString(string $templateString): string
     {
-        return str_replace('{', '${', $templateString);
+        return str_replace('{', '${', TypeScript::escapeTemplateLiteral($templateString));
     }
 }

--- a/src/Converters/Enums.php
+++ b/src/Converters/Enums.php
@@ -31,7 +31,7 @@ class Enums extends Converter
                     ? 'never'
                     : TypeScript::union(
                         collect($enum->cases)
-                            ->map(fn ($case) => is_string($case) ? "'{$case}'" : (string) $case)
+                            ->map(fn ($case) => is_string($case) ? TypeScript::quote($case) : (string) $case)
                             ->values()
                             ->all(),
                     ),

--- a/src/Langs/TypeScript/Converters/RouteMethod.php
+++ b/src/Langs/TypeScript/Converters/RouteMethod.php
@@ -358,7 +358,7 @@ class RouteMethod
                 }
 
                 if ($parameter->default !== null) {
-                    $val = sprintf('(%s) ?? "%s"', $val, $parameter->default);
+                    $val = sprintf('(%s) ?? %s', $val, TypeScript::quote((string) $parameter->default));
                 }
 
                 if (self::hasNullableKey($parameter)) {

--- a/src/Langs/WritesJavaScript.php
+++ b/src/Langs/WritesJavaScript.php
@@ -11,13 +11,16 @@ trait WritesJavaScript
 
     public static function quote(string $string): string
     {
-        foreach (['`', "'", '"'] as $quote) {
-            if (str_starts_with($string, $quote)) {
-                return $string;
-            }
-        }
+        $encoded = json_encode($string, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
 
-        return '"'.$string.'"';
+        // U+2028 and U+2029 are valid in JSON but were only allowed in JavaScript
+        // string literals from ES2019 on, so keep them escaped.
+        return str_replace(["\u{2028}", "\u{2029}"], ['\u2028', '\u2029'], $encoded);
+    }
+
+    public static function escapeTemplateLiteral(string $string): string
+    {
+        return str_replace(['\\', '`', '${'], ['\\\\', '\\`', '\\${'], $string);
     }
 
     public static function quoteKey(string $key): string

--- a/tests/EscapedValues.test.ts
+++ b/tests/EscapedValues.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+import {
+    QuotedEnum,
+    QuotedEnumMeta,
+    Double,
+    Newline,
+} from "../workbench/resources/js/wayfinder/App/Enums/QuotedEnum";
+import { quotedDefaults } from "../workbench/resources/js/wayfinder/App/Http/Controllers/UrlDefaultsController";
+import { BroadcastChannels } from "../workbench/resources/js/wayfinder/broadcast-channels";
+import type { BroadcastChannel } from "../workbench/resources/js/wayfinder/broadcast-channels";
+import type { App } from "../workbench/resources/js/wayfinder/types";
+
+describe("EscapedValues", () => {
+    test("enum values keep their quotes, backslashes and newlines", () => {
+        expect(QuotedEnum.Double).toBe('say "hi"');
+        expect(QuotedEnum.Single).toBe("it's here");
+        expect(QuotedEnum.Backslash).toBe("back\\slash");
+        expect(QuotedEnum.Newline).toBe("line\nbreak");
+    });
+
+    test("exported enum case constants keep their quotes", () => {
+        expect(Double).toBe('say "hi"');
+        expect(Newline).toBe("line\nbreak");
+    });
+
+    test("enum meta is keyed by the escaped case value", () => {
+        expect(QuotedEnumMeta['say "hi"'].label).toBe('A "quoted" label');
+        expect(QuotedEnumMeta["line\nbreak"].label).toBe("multi\nline");
+        expect(QuotedEnumMeta[QuotedEnum.Backslash].label).toBe(
+            "back\\slash label",
+        );
+    });
+
+    test("enum type union escapes case values", () => {
+        expectTypeOf<App.Enums.QuotedEnum>().toEqualTypeOf<
+            'say "hi"' | "it's here" | "back\\slash" | "line\nbreak"
+        >();
+    });
+
+    test("validation in: values are escaped in the request type", () => {
+        expectTypeOf<
+            App.Http.Controllers.PostController.Store.Request["status"]
+        >().toEqualTypeOf<
+            'say "hi"' | "it's" | "back\\slash" | null | undefined
+        >();
+    });
+
+    test("channel names with backticks and dollars are escaped", () => {
+        expect(BroadcastChannels.quirky["`tick`-$dollar"](7)).toBe(
+            "quirky.`tick`-$dollar.7",
+        );
+
+        expectTypeOf<`quirky.\`tick\`-$dollar.${string}`>().toMatchTypeOf<BroadcastChannel>();
+    });
+
+    test("url defaults containing quotes are escaped", () => {
+        expect(quotedDefaults.url()).toBe('/with-quoted-defaults/say "hi" now');
+    });
+});

--- a/tests/Unit/Langs/QuoteTest.php
+++ b/tests/Unit/Langs/QuoteTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Langs;
+
+use Laravel\Wayfinder\Langs\TypeScript;
+use PHPUnit\Framework\TestCase;
+
+class QuoteTest extends TestCase
+{
+    public function test_it_escapes_double_quotes(): void
+    {
+        $this->assertSame('"say \"hi\""', TypeScript::quote('say "hi"'));
+    }
+
+    public function test_it_leaves_single_quotes_alone(): void
+    {
+        $this->assertSame('"it\'s here"', TypeScript::quote("it's here"));
+    }
+
+    public function test_it_escapes_backslashes(): void
+    {
+        $this->assertSame('"back\\\\slash"', TypeScript::quote('back\slash'));
+    }
+
+    public function test_it_escapes_newlines_and_control_characters(): void
+    {
+        $this->assertSame('"line\nbreak"', TypeScript::quote("line\nbreak"));
+        $this->assertSame('"tab\there"', TypeScript::quote("tab\there"));
+    }
+
+    public function test_it_escapes_line_separators(): void
+    {
+        $this->assertSame('"a\\u2028b"', TypeScript::quote("a\u{2028}b"));
+        $this->assertSame('"a\\u2029b"', TypeScript::quote("a\u{2029}b"));
+    }
+
+    public function test_it_leaves_slashes_and_unicode_unescaped(): void
+    {
+        $this->assertSame('"Pages/Users/Edit"', TypeScript::quote('Pages/Users/Edit'));
+        $this->assertSame('"café"', TypeScript::quote('café'));
+    }
+
+    public function test_it_quotes_keys_that_are_not_identifiers(): void
+    {
+        $this->assertSame('foo', TypeScript::quoteKey('foo'));
+        $this->assertSame('"for-sale"', TypeScript::quoteKey('for-sale'));
+        $this->assertSame('"say \"hi\""', TypeScript::quoteKey('say "hi"'));
+    }
+}

--- a/workbench/app/Enums/QuotedEnum.php
+++ b/workbench/app/Enums/QuotedEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum QuotedEnum: string
+{
+    case Double = 'say "hi"';
+    case Single = "it's here";
+    case Backslash = 'back\\slash';
+    case Newline = "line\nbreak";
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Double => 'A "quoted" label',
+            self::Single => "It's a label",
+            self::Backslash => 'back\\slash label',
+            self::Newline => "multi\nline",
+        };
+    }
+}

--- a/workbench/app/Http/Controllers/UrlDefaultsController.php
+++ b/workbench/app/Http/Controllers/UrlDefaultsController.php
@@ -13,4 +13,9 @@ class UrlDefaultsController
     {
         //
     }
+
+    public function quotedDefaults()
+    {
+        //
+    }
 }

--- a/workbench/app/Http/Middleware/UrlDefaultsMiddleware.php
+++ b/workbench/app/Http/Middleware/UrlDefaultsMiddleware.php
@@ -10,6 +10,7 @@ class UrlDefaultsMiddleware
     {
         URL::defaults([
             'locale' => 'en',
+            'quoted' => 'say "hi" now',
         ]);
 
         return $next($request);

--- a/workbench/app/Http/Requests/StorePostRequest.php
+++ b/workbench/app/Http/Requests/StorePostRequest.php
@@ -18,6 +18,7 @@ class StorePostRequest extends FormRequest
     {
         return [
             'title' => ['required', 'string', 'max:255'],
+            'status' => ['nullable', 'in:say "hi",it\'s,back\\slash'],
             'body' => ['required', 'string'],
             'excerpt' => ['nullable', 'string', 'max:500'],
             'published_at' => ['nullable', 'date'],

--- a/workbench/routes/channels.php
+++ b/workbench/routes/channels.php
@@ -17,3 +17,7 @@ Broadcast::channel('chat.{roomId}.messages', function ($user, $roomId) {
 Broadcast::channel('public-announcements', function ($user) {
     return true;
 });
+
+Broadcast::channel('quirky.`tick`-$dollar.{roomId}', function ($user, $roomId) {
+    return true;
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -72,6 +72,7 @@ Route::get('/users/by-token/{user:remember_token}', [ModelBindingController::cla
 
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}', [UrlDefaultsController::class, 'onlyDefaults']);
 Route::middleware(UrlDefaultsMiddleware::class)->post('/with-defaults/{locale}/also/{timezone}', [UrlDefaultsController::class, 'mixedDefaults']);
+Route::middleware(UrlDefaultsMiddleware::class)->post('/with-quoted-defaults/{quoted}', [UrlDefaultsController::class, 'quotedDefaults']);
 
 Route::get('/keys/{key}', [KeyController::class, 'show']);
 Route::get('/keys/{key:uuid}/edit', [KeyController::class, 'edit']);


### PR DESCRIPTION
Any PHP value that ended up as a string literal was wrapped in double quotes without being escaped, so a quote, backslash, or newline in the value produced TypeScript that doesn't parse. This showed up in enum case values and their type unions, `in:` validation rule values, and URL default values.

`quote()` now escapes properly instead of just wrapping. It also no longer skips quoting when a value happens to start with a quote character, which silently emitted bare values before.

Broadcast channel names go into template literals rather than quoted strings, so those escape backticks and `${` on the way out.

One visible change to existing output: enum type unions now use double quotes instead of single, matching every other literal we generate.
