### PR TITLE
Add the `WayfinderIgnore` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ function displayUser(user: App.Models.User) {
 }
 ```
 
+Attributes listed in `$hidden` are left out, as is anything marked with the `WayfinderIgnore` attribute — see [Leaving Things Out](#leaving-things-out).
+
 ## PHP Enums
 
 Wayfinder converts PHP enums to TypeScript types and constants.
@@ -338,6 +340,8 @@ function setStatus(status: App.Enums.PostStatus) {
     // Only accepts 'draft', 'published', or 'archived'
 }
 ```
+
+A case can be left out of the generated enum, either always or only for some builds — see [Leaving Things Out](#leaving-things-out).
 
 ### Enum Methods
 
@@ -616,6 +620,158 @@ This provides autocomplete and type-checking for `import.meta.env`:
 const appName = import.meta.env.VITE_APP_NAME;
 ```
 
+## Leaving Things Out
+
+Some of what Wayfinder can see should not reach the browser. Mark it with the `WayfinderIgnore` attribute and nothing is generated for it:
+
+```php
+use Laravel\Wayfinder\Attributes\WayfinderIgnore;
+
+#[WayfinderIgnore]
+class InternalController
+{
+    // No action file, no route helper, no request type.
+}
+```
+
+The attribute works on a controller class or a single action, a model, an enum or one of its cases, a broadcast event or channel, and on a model's accessors and relations:
+
+```php
+class UserController
+{
+    public function index() { /* generated */ }
+
+    #[WayfinderIgnore]
+    public function impersonate() { /* not generated */ }
+}
+```
+
+```php
+class User extends Model
+{
+    #[WayfinderIgnore]
+    public function auditEntries(): HasMany
+    {
+        return $this->hasMany(AuditEntry::class);
+    }
+}
+```
+
+Dropping an action drops everything that hangs off it: the route helper, the form variant, the page type, and the request type. Dropping a model drops relations that point at it, since there is no type left to point to.
+
+### Keeping Something For Some Builds Only
+
+Some declarations belong in local builds and nowhere else: a fake source provider, a seeding endpoint, a debug page. Pass `unless` and the declaration is kept only while the condition holds:
+
+```php
+// config/services.php
+'fake_source_provider' => env('FAKE_SOURCE_PROVIDER', false),
+
+// App\Enums\SourceProvider
+enum SourceProvider: string
+{
+    case Github = 'github';
+    case Gitlab = 'gitlab';
+
+    #[WayfinderIgnore(unless: 'services.fake_source_provider')]
+    case GitFake = 'gitfake';
+}
+```
+
+Locally, with the flag on:
+
+```typescript
+export type SourceProvider = "github" | "gitlab" | "gitfake";
+```
+
+In production, with the flag off or missing:
+
+```typescript
+export type SourceProvider = "github" | "gitlab";
+```
+
+`when` is the other way round, for something to leave out while a condition holds rather than keep:
+
+```php
+class DebugController
+{
+    #[WayfinderIgnore(when: 'services.hide_debug_tools')]
+    public function dump() { /* ... */ }
+}
+```
+
+Either takes a config key, or a `[class, method]` callable for a condition with real logic behind it:
+
+```php
+#[WayfinderIgnore(unless: [SourceProviders::class, 'fakeEnabled'])]
+```
+
+Whatever you pass is answered when the files are generated, by the environment generating them. Wayfinder's output is regenerated per build, so each build gets the answer for where it runs. Nothing is remembered between builds: the analysis cache holds the condition, never the answer to it.
+
+| Condition | `unless` | `when` |
+| --------- | -------- | ------ |
+| Passes | Kept | Left out |
+| Fails, or the config key is missing | Left out | Kept |
+| Cannot be read | Left out | Left out |
+
+A condition Wayfinder cannot read leaves the declaration out whichever argument it was written with, so a typo shows up as a type error rather than shipping something. Only a config key or a callable counts as a condition, so `#[WayfinderIgnore(true)]` is not a way to switch a marker on or off — it is a marker with no condition, which leaves the declaration out. Passing both arguments is allowed and each can only add hiding, so `unless` keeping something does not override `when` leaving it out. Reach for one or the other.
+
+One consequence worth planning for: the production build genuinely does not have the member, so code that reads it has to sit somewhere the production build never typechecks.
+
+### Payload Keys
+
+An attribute cannot go on an array key, so mark those with a comment instead. Put `@wayfinder-ignore` above the key or at the end of its line:
+
+```php
+return Inertia::render('Profile', [
+    'name' => $user->name,
+    'apiToken' => $user->api_token, // @wayfinder-ignore
+    'billing' => [
+        'plan' => $user->plan,
+        // @wayfinder-ignore
+        'stripeId' => $user->stripe_id,
+    ],
+]);
+```
+
+```typescript
+export type Profile = Inertia.SharedData & {
+    name: string;
+    billing: { plan: string };
+};
+```
+
+The key is gone, not emptied, so code that still reads it fails to compile. This works anywhere Wayfinder reads an array: page props, `toArray()` on a resource, `broadcastWith()`, and the rules of a form request.
+
+A marker hides a member from its own type. If something else hands the same value out under a key of its own, that key needs its own marker.
+
+For a plain database column on a model, Eloquent's `$hidden` and `#[Hidden]` already keep it out, and Wayfinder follows them.
+
+### Traits
+
+Nothing is generated for a trait, so a marker on the trait itself has nothing to hide. Mark the members inside it, which works whether the trait is used by one model or twenty:
+
+```php
+trait HasAvatar
+{
+    #[WayfinderIgnore]
+    public function avatarPath(): Attribute { /* ... */ }
+}
+```
+
+### Markers From Other Packages
+
+To honor an attribute you cannot change, or a different comment tag, list them in `config/wayfinder.php`:
+
+```php
+'ignore' => [
+    'attributes' => [\Vendor\Package\Attributes\Internal::class],
+    'tags' => ['wayfinder-ignore', 'ignore'],
+],
+```
+
+Your own attributes need no registration. Any attribute implementing `Laravel\Surveyor\Contracts\Ignored` is honored.
+
 ## Configuration
 
 The configuration file is located at `config/wayfinder.php`:
@@ -623,6 +779,10 @@ The configuration file is located at `config/wayfinder.php`:
 ```php
 return [
     'generate' => [
+        'ignore' => [
+            'attributes' => [],
+            'tags' => ['wayfinder-ignore'],
+        ],
         'route' => [
             'actions' => env('WAYFINDER_GENERATE_ROUTE_ACTIONS', true),
             'named' => env('WAYFINDER_GENERATE_NAMED_ROUTES', true),
@@ -660,6 +820,8 @@ return [
 
 | Option                           | Description                            | Default                   |
 | -------------------------------- | -------------------------------------- | ------------------------- |
+| `generate.ignore.attributes`     | Extra attributes that leave a declaration out | `[]`               |
+| `generate.ignore.tags`           | Comment tags that leave an array key out | `['wayfinder-ignore']`  |
 | `generate.route.actions`         | Generate controller action files       | `true`                    |
 | `generate.route.named`           | Generate named route files             | `true`                    |
 | `generate.route.form_variant`    | Include `.form` method variants        | `true`                    |

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "illuminate/filesystem": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ranger": "^0.3.0",
-        "laravel/surveyor": "^0.2.7",
+        "laravel/ranger": "^0.4.0",
+        "laravel/surveyor": "^0.3.0",
         "phpstan/phpdoc-parser": "^2.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/filesystem": "^12.0|^13.0",
         "illuminate/routing": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0",
-        "laravel/ranger": "^0.4.0",
+        "laravel/ranger": "^0.5.0",
         "laravel/surveyor": "^0.3.0",
         "phpstan/phpdoc-parser": "^2.3"
     },

--- a/config/wayfinder.php
+++ b/config/wayfinder.php
@@ -2,6 +2,13 @@
 
 return [
     'generate' => [
+        // Leave declarations out of the generated files
+        'ignore' => [
+            // Attribute classes treated the same as Laravel\Wayfinder\Attributes\WayfinderIgnore
+            'attributes' => [],
+            // Comment tags that leave out the array key they sit on
+            'tags' => ['wayfinder-ignore'],
+        ],
         'route' => [
             'actions' => env('WAYFINDER_GENERATE_ROUTE_ACTIONS', true),
             'named' => env('WAYFINDER_GENERATE_NAMED_ROUTES', true),

--- a/src/Attributes/WayfinderIgnore.php
+++ b/src/Attributes/WayfinderIgnore.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\Wayfinder\Attributes;
+
+use Attribute;
+use Laravel\Surveyor\Contracts\ConditionallyIgnored;
+
+/**
+ * Leave the marked declaration out of the generated TypeScript.
+ *
+ * On a class, nothing is generated for it at all. On a controller method, the
+ * route it handles is dropped along with its form variant, page type, and
+ * request type. On a property, accessor, relation, or enum case, that member is
+ * dropped from the type around it.
+ *
+ * Pass `unless` to keep it only while a condition holds, or `when` to leave it
+ * out only while one holds. Since generation runs per build, a condition is
+ * answered by the environment that generated the files. A condition Wayfinder
+ * cannot read leaves the declaration out either way.
+ */
+#[Attribute(Attribute::TARGET_ALL)]
+final class WayfinderIgnore implements ConditionallyIgnored
+{
+    /**
+     * @param  string|array{0: class-string, 1: string}|null  $unless  Keep it while this passes: a config key or a [class, method] callable.
+     * @param  string|array{0: class-string, 1: string}|null  $when  Leave it out while this passes.
+     */
+    public function __construct(
+        public readonly string|array|null $unless = null,
+        public readonly string|array|null $when = null,
+    ) {
+        //
+    }
+
+    public function unless(): string|array|null
+    {
+        return $this->unless;
+    }
+
+    public function when(): string|array|null
+    {
+        return $this->when;
+    }
+}

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\File;
 use Laravel\Ranger\Ranger;
 use Laravel\Ranger\Support\Config as RangerConfig;
 use Laravel\Surveyor\Analyzer\AnalyzedCache;
+use Laravel\Surveyor\Support\Markers;
 use Laravel\Wayfinder\Converters\BroadcastChannels;
 use Laravel\Wayfinder\Converters\BroadcastEvents;
 use Laravel\Wayfinder\Converters\Enums;
@@ -61,6 +62,8 @@ class GenerateCommand extends Command
     ) {
         AnalyzedCache::freezeFileTimes();
         AnalyzedCache::setCacheDirectory($this->config->get('wayfinder.cache.directory'));
+
+        $this->registerIgnoreMarkers();
 
         $cacheEnabled = $this->config->get('wayfinder.cache.enabled');
 
@@ -142,6 +145,22 @@ class GenerateCommand extends Command
         $this->ranger->walk();
 
         $this->writeFiles();
+    }
+
+    /**
+     * Tell the analyzer which attributes and comment tags mean "leave this
+     * out", and fold them into the cache key: they decide what ends up in the
+     * generated files, so a cached run must not answer for a different set.
+     */
+    protected function registerIgnoreMarkers(): void
+    {
+        $attributes = $this->config->get('wayfinder.generate.ignore.attributes', []);
+        $tags = $this->config->get('wayfinder.generate.ignore.tags', ['wayfinder-ignore']);
+
+        Markers::registerAttributes(...$attributes);
+        Markers::registerTags(...$tags);
+
+        AnalyzedCache::setKey(hash('sha256', serialize([$attributes, $tags])));
     }
 
     protected function getBasePaths(): array

--- a/tests/Feature/ConditionalIgnoreTest.php
+++ b/tests/Feature/ConditionalIgnoreTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+use function Illuminate\Filesystem\join_paths;
+
+class ConditionalIgnoreTest extends TestCase
+{
+    private string $rootPath;
+
+    private string $cachePath;
+
+    private array $generatedPaths = [];
+
+    private Filesystem $files;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->rootPath = realpath(join_paths(__DIR__, '..', '..'));
+        $this->cachePath = join_paths(sys_get_temp_dir(), 'wayfinder-condition-cache-'.uniqid());
+
+        $envExample = join_paths($this->rootPath, 'workbench', '.env.example');
+        $envFile = join_paths($this->rootPath, 'workbench', '.env');
+
+        if ($this->files->exists($envExample) && ! $this->files->exists($envFile)) {
+            $this->files->copy($envExample, $envFile);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([...$this->generatedPaths, $this->cachePath] as $path) {
+            $this->files->deleteDirectory($path);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_a_condition_decides_per_build_even_when_the_analysis_is_cached(): void
+    {
+        $off = $this->generate(fake: false);
+
+        $this->assertStringContainsString('export const Gitlab = "gitlab"', $off);
+        $this->assertStringNotContainsString('GitFake', $off);
+
+        // Same cache directory, so the second run reads the analysis written by
+        // the first: the condition has to be answered after the cache, not
+        // baked into it.
+        $on = $this->generate(fake: true);
+
+        $this->assertStringContainsString('export const GitFake = "gitfake"', $on);
+
+        $this->assertStringNotContainsString('GitFake', $this->generate(fake: false));
+    }
+
+    public function test_a_when_condition_leaves_a_case_out_only_while_it_passes(): void
+    {
+        $hidden = $this->generate(hideRetired: true);
+
+        $this->assertStringNotContainsString('GitRetired', $hidden);
+
+        $shown = $this->generate(hideRetired: false);
+
+        $this->assertStringContainsString('export const GitRetired = "gitretired"', $shown);
+    }
+
+    private function generate(bool $fake = false, bool $hideRetired = true): string
+    {
+        $path = join_paths(sys_get_temp_dir(), 'wayfinder-condition-'.uniqid());
+        $this->generatedPaths[] = $path;
+
+        $process = new Process([
+            join_paths($this->rootPath, 'vendor', 'bin', 'testbench'),
+            'wayfinder:generate',
+            '--path='.$path,
+            '--app-path='.join_paths($this->rootPath, 'workbench', 'app'),
+            '--base-path='.join_paths($this->rootPath, 'workbench'),
+        ], $this->rootPath, [
+            'WAYFINDER_CACHE_ENABLED' => 'true',
+            'WAYFINDER_CACHE_DIRECTORY' => $this->cachePath,
+            'WORKBENCH_FAKE_SOURCE_PROVIDER' => $fake ? '1' : '',
+            'WORKBENCH_HIDE_RETIRED_SOURCE_PROVIDER' => $hideRetired ? '1' : '0',
+        ]);
+
+        $process->setTimeout(120);
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            'wayfinder:generate failed: '.$process->getErrorOutput().$process->getOutput()
+        );
+
+        return $this->files->get(join_paths($path, 'App', 'Enums', 'SourceProvider.ts'));
+    }
+}

--- a/tests/Ignore.test.ts
+++ b/tests/Ignore.test.ts
@@ -1,0 +1,108 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, test } from "vitest";
+
+describe("Ignore", () => {
+    const wayfinderPath = join(__dirname, "../workbench/resources/js/wayfinder");
+    const types = () =>
+        readFileSync(join(wayfinderPath, "types.d.ts"), "utf-8");
+
+    test("nothing is generated for a marked controller", () => {
+        expect(types()).not.toContain("IgnoredController");
+        expect(
+            existsSync(
+                join(wayfinderPath, "App/Http/Controllers/IgnoredController.ts"),
+            ),
+        ).toBe(false);
+    });
+
+    test("a marked method is dropped and its siblings are kept", () => {
+        const controller = readFileSync(
+            join(wayfinderPath, "App/Http/Controllers/SecretsController.ts"),
+            "utf-8",
+        );
+
+        expect(controller).toContain("export const index");
+        expect(controller).not.toContain("reveal");
+        expect(types()).not.toContain("Inertia.Pages.Reveal");
+    });
+
+    test("a marked page prop is dropped from the page type", () => {
+        const secrets = types()
+            .split("export type Secrets")[1]
+            ?.split("export type")[0];
+
+        expect(secrets).toBeDefined();
+        expect(secrets).toContain("name: string");
+        expect(secrets).toContain("email: string");
+        expect(secrets).not.toContain("socialSecurityNumber");
+    });
+
+    test("a marked prop nested in a page prop is dropped", () => {
+        const secrets = types()
+            .split("export type Secrets")[1]
+            ?.split("export type")[0];
+
+        expect(secrets).toContain("label: string");
+        expect(secrets).not.toContain("routingNumber");
+    });
+
+    test("a marked toArray leaves the action without a response shape", () => {
+        const controller =
+            types().split("export namespace SecretsController")[1] ?? "";
+        const resource = controller
+            .split("export namespace Resource {")[1]
+            ?.split("export namespace")[0];
+
+        expect(resource).toBeDefined();
+        expect(resource).toContain("export type Request");
+        expect(resource).not.toContain("export type Response");
+        expect(types()).not.toContain("socialSecurityNumber");
+    });
+
+    test("nothing is generated for a marked model", () => {
+        expect(types()).not.toContain("AuditLog");
+    });
+
+    test("a marked relation is dropped from the model type", () => {
+        const user = types()
+            .split("export type User")[1]
+            ?.split("export type")[0];
+
+        expect(user).toBeDefined();
+        expect(user).not.toContain("auditEntries");
+    });
+
+    test("a case is dropped when its unless condition fails", () => {
+        const sourceProvider = readFileSync(
+            join(wayfinderPath, "App/Enums/SourceProvider.ts"),
+            "utf-8",
+        );
+
+        expect(sourceProvider).toContain('export const Github = "github"');
+        expect(sourceProvider).toContain("{ Github, Gitlab }");
+        expect(sourceProvider).not.toContain("GitFake");
+        expect(types()).toContain(
+            'export type SourceProvider = "github" | "gitlab"',
+        );
+    });
+
+    test("a case is dropped when its when condition passes", () => {
+        const sourceProvider = readFileSync(
+            join(wayfinderPath, "App/Enums/SourceProvider.ts"),
+            "utf-8",
+        );
+
+        expect(sourceProvider).not.toContain("GitRetired");
+        expect(types()).not.toContain("gitretired");
+    });
+
+    test("routes for marked actions are not registered", () => {
+        const routeFiles = readFileSync(
+            join(wayfinderPath, "routes/index.ts"),
+            "utf-8",
+        );
+
+        expect(routeFiles).not.toContain("ignored");
+    });
+});

--- a/workbench/app/Enums/SourceProvider.php
+++ b/workbench/app/Enums/SourceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+use Laravel\Wayfinder\Attributes\WayfinderIgnore;
+
+enum SourceProvider: string
+{
+    case Github = 'github';
+
+    case Gitlab = 'gitlab';
+
+    #[WayfinderIgnore(unless: 'features.fake_source_provider')]
+    case GitFake = 'gitfake';
+
+    #[WayfinderIgnore(when: 'features.hide_retired_source_provider')]
+    case GitRetired = 'gitretired';
+}

--- a/workbench/app/Http/Controllers/IgnoredController.php
+++ b/workbench/app/Http/Controllers/IgnoredController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Wayfinder\Attributes\WayfinderIgnore;
+
+#[WayfinderIgnore]
+class IgnoredController
+{
+    public function index(): JsonResponse
+    {
+        return response()->json([
+            'internalOnly' => 'value',
+        ]);
+    }
+}

--- a/workbench/app/Http/Controllers/SecretsController.php
+++ b/workbench/app/Http/Controllers/SecretsController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\SecretResource;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Wayfinder\Attributes\WayfinderIgnore;
+
+class SecretsController
+{
+    public function index(): Response
+    {
+        return Inertia::render('Secrets', [
+            'name' => 'Taylor',
+            'socialSecurityNumber' => '000-00-0000', // @wayfinder-ignore
+            'account' => [
+                'label' => 'Primary',
+                // @wayfinder-ignore
+                'routingNumber' => '000000000',
+            ],
+            'email' => 'taylor@laravel.com',
+        ]);
+    }
+
+    public function resource(): JsonResource
+    {
+        return new SecretResource(null);
+    }
+
+    #[WayfinderIgnore]
+    public function reveal(): Response
+    {
+        return Inertia::render('Reveal', [
+            'internalOnly' => 'value',
+        ]);
+    }
+}

--- a/workbench/app/Http/Resources/SecretResource.php
+++ b/workbench/app/Http/Resources/SecretResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Laravel\Wayfinder\Attributes\WayfinderIgnore;
+
+class SecretResource extends JsonResource
+{
+    #[WayfinderIgnore]
+    public function toArray(Request $request): array
+    {
+        return [
+            'socialSecurityNumber' => '000-00-0000',
+        ];
+    }
+}

--- a/workbench/app/Models/AuditLog.php
+++ b/workbench/app/Models/AuditLog.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Wayfinder\Attributes\WayfinderIgnore;
+
+/**
+ * @property int $id
+ * @property string $internalNote
+ */
+#[WayfinderIgnore]
+class AuditLog extends Model
+{
+    //
+}

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
+use Laravel\Wayfinder\Attributes\WayfinderIgnore;
 
 /**
  * @property int $id
@@ -75,5 +76,14 @@ class User extends Authenticatable
     public function favoriteCategories(): HasMany
     {
         return $this->hasMany(Category::class);
+    }
+
+    /**
+     * @return HasMany<AuditLog, $this>
+     */
+    #[WayfinderIgnore]
+    public function auditEntries(): HasMany
+    {
+        return $this->hasMany(AuditLog::class);
     }
 }

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -22,6 +22,11 @@ class WorkbenchServiceProvider extends ServiceProvider
             ],
         ]);
 
+        Config::set([
+            'features.fake_source_provider' => env('WORKBENCH_FAKE_SOURCE_PROVIDER', false),
+            'features.hide_retired_source_provider' => env('WORKBENCH_HIDE_RETIRED_SOURCE_PROVIDER', true),
+        ]);
+
         URL::defaults([
             'defaultDomain' => 'tim.macdonald',
         ]);

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\DisallowedMethodNameController;
 use App\Http\Controllers\DomainController;
 use App\Http\Controllers\DuplicateInertiaController;
 use App\Http\Controllers\EloquentProductController;
+use App\Http\Controllers\IgnoredController;
 use App\Http\Controllers\InertiaController;
 use App\Http\Controllers\InvokableController;
 use App\Http\Controllers\InvokablePlusController;
@@ -23,6 +24,7 @@ use App\Http\Controllers\PostController;
 use App\Http\Controllers\Prism\Prism\PrismController as NestedPrismController;
 use App\Http\Controllers\Prism\PrismController;
 use App\Http\Controllers\ResourceTestController;
+use App\Http\Controllers\SecretsController;
 use App\Http\Controllers\TwoRoutesSameActionController;
 use App\Http\Controllers\UrlDefaultsController;
 use App\Http\Middleware\UrlDefaultsMiddleware;
@@ -159,3 +161,8 @@ Route::prefix('mixed')->name('mixed.')->group(function () {
     Route::get('items/{item}', [MixedRouteController::class, 'edit'])->name('items.edit');
     Route::patch('items/{item}', [MixedRouteController::class, 'update'])->name('items.update');
 });
+
+Route::get('ignored-controller', [IgnoredController::class, 'index'])->name('ignored.index');
+Route::get('secrets', [SecretsController::class, 'index'])->name('secrets.index');
+Route::get('secrets/reveal', [SecretsController::class, 'reveal'])->name('secrets.reveal');
+Route::get('secrets/resource', [SecretsController::class, 'resource'])->name('secrets.resource');


### PR DESCRIPTION
Some of what Wayfinder can see should not reach the browser. Marking a declaration with `#[WayfinderIgnore]` leaves it out of the generated files: a controller class or action, along with its route helper, form variant, page type and request type, a model, an enum or one of its cases, a broadcast event or channel, and a model's accessors and relations. An array key cannot take an attribute, so a `@wayfinder-ignore` comment covers page props, resource payloads and validation rules.

Passing unless or when keeps or drops the declaration based on a config key or a callable, which covers what belongs in local builds only, such as a fake source provider. Generation runs per build, so each environment gets its own answer, and a condition that cannot be read leaves the declaration out rather than shipping it.

Attributes from other packages and extra comment tags can be listed in config, and the ignore config is folded into the analysis cache key so a change to it is never served from cache.
