### PR TITLE
Fix nested index route imports

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -393,7 +393,12 @@ class GenerateCommand extends Command
         if (! ($this->content[$indexPath] ?? false)) {
             $imports = $childKeys->filter(fn ($_, $key) => $key !== 'index')->map(fn ($alias, $key) => "import {$alias['safe']} from './{$key}'")->implode(PHP_EOL);
         } else {
-            $imports = $childKeys->only($keysWithGrandkids->keys())->map(fn ($alias, $key) => "import {$alias['safe']} from './{$key}'")->implode(PHP_EOL);
+            $imports = $childKeys->only($keysWithGrandkids->keys())->map(function ($alias, $key) {
+                // A leaf named `index` shares its path with a nested index barrel.
+                $path = $key === 'index' ? './index/index' : "./{$key}";
+
+                return "import {$alias['safe']} from '{$path}'";
+            })->implode(PHP_EOL);
         }
 
         if ($imports) {

--- a/tests/Feature/PruneStaleFilesTest.php
+++ b/tests/Feature/PruneStaleFilesTest.php
@@ -29,6 +29,8 @@ class PruneStaleFilesTest extends TestCase
 
         Route::get('/prune-test/alpha', fn () => '')->name('prune.test.alpha');
         Route::get('/prune-test/beta', fn () => '')->name('prune.test.beta');
+        Route::get('/photos', fn () => '')->name('photos.index');
+        Route::get('/photos/window', fn () => '')->name('photos.index.window');
     }
 
     protected function tearDown(): void
@@ -55,6 +57,16 @@ class PruneStaleFilesTest extends TestCase
         $this->assertDirectoryExists($routes);
         $this->assertNotEmpty($this->files->allFiles($routes));
         $this->assertFileExists(join_paths($routes, 'prune', 'test', 'index.ts'));
+    }
+
+    public function test_leaf_index_route_imports_nested_index_barrel(): void
+    {
+        $this->generate();
+
+        $index = $this->files->get(join_paths($this->tempPath, 'routes', 'photos', 'index.ts'));
+
+        $this->assertStringContainsString("from './index/index'", $index);
+        $this->assertStringNotContainsString("from './index'", str_replace("from './index/index'", '', $index));
     }
 
     public function test_stale_files_are_removed_while_current_files_are_kept(): void


### PR DESCRIPTION
Closes #311

## Summary

- disambiguate a leaf route named `index` from its nested index barrel
- import the nested barrel from `./index/index` instead of self-importing `./index`
- add regression coverage for `photos.index` together with `photos.index.window`

## Root cause

When both route names exist, the generated `photos/index.ts` barrel shares a path with the leaf route. Importing `./index` therefore resolves back to the current module and silently drops the nested route helper.

## User impact

Nested route helpers remain available to TypeScript and bundlers without changing generated imports for other route names.

## Validation

- `vendor/bin/phpunit --filter PruneStaleFilesTest` - 7 passed, 30 assertions
- strict TypeScript compilation, esbuild, and runtime descendant assertions - passed
- `git diff --check` - passed

Repository-wide formatting still reports pre-existing CRLF/style drift outside this focused change.

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
