### PR TITLE
Fix barrel self-import when a route name is both a leaf and a prefix …

### DIFF
--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -397,6 +397,7 @@ class GenerateCommand extends Command
 
         $importable = ($this->content[$indexPath] ?? false)
             ? $childKeys->only($keysWithGrandkids->keys())
+            // A childless "index" is a leaf written into this same file, so it needs no import.
             : $childKeys->filter(fn ($_, $key) => $key !== 'index' || $keysWithGrandkids->has($key));
 
         $imports = $importable->map(fn ($alias, $key) => "import {$alias['safe']} from '{$importPath($key)}'")->implode(PHP_EOL);

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -395,11 +395,11 @@ class GenerateCommand extends Command
         // by its full path or the barrel silently ends up importing itself.
         $importPath = fn ($key) => $key === 'index' ? './index/index' : "./{$key}";
 
-        if (! ($this->content[$indexPath] ?? false)) {
-            $imports = $childKeys->filter(fn ($_, $key) => $key !== 'index' || $keysWithGrandkids->has($key))->map(fn ($alias, $key) => "import {$alias['safe']} from '{$importPath($key)}'")->implode(PHP_EOL);
-        } else {
-            $imports = $childKeys->only($keysWithGrandkids->keys())->map(fn ($alias, $key) => "import {$alias['safe']} from '{$importPath($key)}'")->implode(PHP_EOL);
-        }
+        $importable = ($this->content[$indexPath] ?? false)
+            ? $childKeys->only($keysWithGrandkids->keys())
+            : $childKeys->filter(fn ($_, $key) => $key !== 'index' || $keysWithGrandkids->has($key));
+
+        $imports = $importable->map(fn ($alias, $key) => "import {$alias['safe']} from '{$importPath($key)}'")->implode(PHP_EOL);
 
         if ($imports) {
             $this->prependContent($indexPath, $imports);

--- a/src/GenerateCommand.php
+++ b/src/GenerateCommand.php
@@ -390,10 +390,15 @@ class GenerateCommand extends Command
             ];
         });
 
+        // A child named "index" is written to "index/index.ts", but every resolver
+        // prefers the sibling "index.ts" for "./index", so it has to be imported
+        // by its full path or the barrel silently ends up importing itself.
+        $importPath = fn ($key) => $key === 'index' ? './index/index' : "./{$key}";
+
         if (! ($this->content[$indexPath] ?? false)) {
-            $imports = $childKeys->filter(fn ($_, $key) => $key !== 'index')->map(fn ($alias, $key) => "import {$alias['safe']} from './{$key}'")->implode(PHP_EOL);
+            $imports = $childKeys->filter(fn ($_, $key) => $key !== 'index' || $keysWithGrandkids->has($key))->map(fn ($alias, $key) => "import {$alias['safe']} from '{$importPath($key)}'")->implode(PHP_EOL);
         } else {
-            $imports = $childKeys->only($keysWithGrandkids->keys())->map(fn ($alias, $key) => "import {$alias['safe']} from './{$key}'")->implode(PHP_EOL);
+            $imports = $childKeys->only($keysWithGrandkids->keys())->map(fn ($alias, $key) => "import {$alias['safe']} from '{$importPath($key)}'")->implode(PHP_EOL);
         }
 
         if ($imports) {

--- a/tests/IndexNamedRoute.test.ts
+++ b/tests/IndexNamedRoute.test.ts
@@ -1,0 +1,12 @@
+import { expect, it } from "vitest";
+import albums from "../workbench/resources/js/routes/albums";
+import photos from "../workbench/resources/js/routes/photos";
+
+it("can handle a route name that is both a leaf and a prefix of 'index'", () => {
+    expect(photos.index().url).toBe("/photos");
+    expect(photos.index.window().url).toBe("/photos/window");
+});
+
+it("can handle an 'index' prefix with no leaf route of its own", () => {
+    expect(albums.index.recent().url).toBe("/albums/recent");
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -99,3 +99,8 @@ Route::prefix('/api/v1')->name('api.v1.')->group(function () {
         Route::get('/', fn () => 'ok')->name('index');
     });
 });
+
+Route::get('/photos', fn () => 'ok')->name('photos.index');
+Route::get('/photos/window', fn () => 'ok')->name('photos.index.window');
+
+Route::get('/albums/recent', fn () => 'ok')->name('albums.index.recent');


### PR DESCRIPTION
…of "index"

A barrel child named "index" is written to "index/index.ts", but the generated import referenced "./index". Every resolver prefers the sibling "index.ts", so the barrel imported itself.

With `photos.index` and `photos.index.window`, `photos/index.ts` emitted `import index<hash> from './index'`, producing TS7022 and TS2303 under tsc. Bundlers accepted it silently because `Object.assign(index, undefined)` is a no-op, so `photos.index.window` was dropped with no warning.

When the "index" prefix has no leaf route of its own, such as `albums.index.recent`, the previous `$key !== 'index'` filter removed the import altogether while still emitting `Object.assign(index, index)`, leaving `index` undeclared: TS2304, and a ReferenceError at runtime.

Import such a child by its full path instead, and narrow the filter so it only drops an "index" child that has no grandchildren, keeping the actions path unchanged.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
