### PR TITLE
[next] Fix barrel self-import when a route name is both a leaf and a prefix of "index"

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -422,7 +422,12 @@ class GenerateCommand extends Command
         }
 
         foreach ($dirs as $d) {
-            $imports->addWildcard("./{$d}", TypeScript::safeMethod($d, 'Method'), default: true);
+            // A subdirectory named "index" holds its barrel at "index/index.ts",
+            // but every resolver prefers the sibling "index.ts" for "./index", so
+            // it has to be named in full or this barrel imports itself.
+            $from = $d === 'index' ? './index/index' : "./{$d}";
+
+            $imports->addWildcard($from, TypeScript::safeMethod($d, 'Method'), default: true);
             $object->key(TypeScript::safeMethod($d, 'Method'))->rawKey();
         }
 

--- a/src/Converters/Routes.php
+++ b/src/Converters/Routes.php
@@ -133,7 +133,7 @@ class Routes extends Converter
 
                     $inFile = in_array($firstSubDir, array_column($this->exports[$path], 'originalMethod'));
 
-                    $resultImports->addDefault('./'.$firstSubDir, $safeFirstSubDirMethod = TypeScript::safeMethod($firstSubDir, 'Method'), safe: $inFile);
+                    $resultImports->addDefault($this->subDirImportPath($firstSubDir), $safeFirstSubDirMethod = TypeScript::safeMethod($firstSubDir, 'Method'), safe: $inFile);
 
                     $subDirImportNames->push($safeFirstSubDirMethod);
 
@@ -200,6 +200,16 @@ class Routes extends Converter
             ->filter(fn (Route $route) => $route->name())
             ->groupBy(fn (Route $route) => str_contains($route->name(), '.') ? str($route->name())->beforeLast('.')->toString() : '')
             ->each($this->writeNamedFile(...));
+    }
+
+    /**
+     * A subdirectory named "index" holds its barrel at "index/index.ts", but
+     * every resolver prefers the sibling "index.ts" for "./index", so it has
+     * to be named in full or the barrel silently imports itself.
+     */
+    protected function subDirImportPath(string $subDir): string
+    {
+        return $subDir === 'index' ? './index/index' : './'.$subDir;
     }
 
     protected function writeNamedFile(Collection $routes, string $namespace): void

--- a/tests/IndexNamedRoute.test.ts
+++ b/tests/IndexNamedRoute.test.ts
@@ -1,0 +1,12 @@
+import { expect, it } from "vitest";
+import albums from "../workbench/resources/js/wayfinder/routes/albums";
+import photos from "../workbench/resources/js/wayfinder/routes/photos";
+
+it("can handle a route name that is both a leaf and a prefix of 'index'", () => {
+    expect(photos.index().url).toBe("/photos");
+    expect(photos.index.window().url).toBe("/photos/window");
+});
+
+it("can handle an 'index' prefix with no leaf route of its own", () => {
+    expect(albums.index.recent().url).toBe("/albums/recent");
+});

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -171,3 +171,8 @@ Route::get('ignored-controller', [IgnoredController::class, 'index'])->name('ign
 Route::get('secrets', [SecretsController::class, 'index'])->name('secrets.index');
 Route::get('secrets/reveal', [SecretsController::class, 'reveal'])->name('secrets.reveal');
 Route::get('secrets/resource', [SecretsController::class, 'resource'])->name('secrets.resource');
+
+Route::get('/photos', fn () => 'ok')->name('photos.index');
+Route::get('/photos/window', fn () => 'ok')->name('photos.index.window');
+
+Route::get('/albums/recent', fn () => 'ok')->name('albums.index.recent');


### PR DESCRIPTION
Bringing https://github.com/laravel/wayfinder/pull/317 into `next`
