### PR TITLE
[next] Fix generated Echo event names and payload declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,12 +585,16 @@ Wayfinder generates:
 
 ```typescript
 export type BroadcastEvent =
-    | ".App.Events.OrderShipped"
-    | ".App.Events.UserNotification";
+    | ".App\\Events\\OrderShipped"
+    | ".App\\Events\\UserNotification";
 
 export const BroadcastEvents = {
-    "App.Events.OrderShipped": ".App.Events.OrderShipped",
-    "App.Events.UserNotification": ".App.Events.UserNotification",
+    App: {
+        Events: {
+            OrderShipped: ".App\\Events\\OrderShipped",
+            UserNotification: ".App\\Events\\UserNotification",
+        },
+    },
 } as const;
 
 // Event payload types in types.d.ts
@@ -609,9 +613,12 @@ If you have `@laravel/echo-vue` or `@laravel/echo-react` installed, Wayfinder ge
 
 ```typescript
 // echo-broadcast-events.d.ts
+import "@laravel/echo-vue";
+import { App } from "./types";
+
 declare module "@laravel/echo-vue" {
     interface Events {
-        ".App.Events.OrderShipped": {
+        ".App\\Events\\OrderShipped": {
             orderId: number;
             trackingNumber: string;
             carrier: string;
@@ -623,7 +630,10 @@ declare module "@laravel/echo-vue" {
 This provides full type safety when listening to events:
 
 ```typescript
-useEcho("orders." + orderId).listen("OrderShipped", (e) => {
+import { useEcho } from "@laravel/echo-vue";
+import { BroadcastEvents } from "@/wayfinder/broadcast-events";
+
+useEcho("orders." + orderId, BroadcastEvents.App.Events.OrderShipped, (e) => {
     // e is fully typed!
     console.log(e.trackingNumber);
 });

--- a/README.md
+++ b/README.md
@@ -614,7 +614,6 @@ If you have `@laravel/echo-vue` or `@laravel/echo-react` installed, Wayfinder ge
 ```typescript
 // echo-broadcast-events.d.ts
 import "@laravel/echo-vue";
-import { App } from "./types";
 
 declare module "@laravel/echo-vue" {
     interface Events {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
         "@laravel/echo-react": "^2.5.0",
         "@laravel/echo-vue": "^2.5.0",
         "@types/node": "^22.7.5",
+        "@types/react": "^19.3.0",
         "axios": "^1.20.0",
         "eslint": "^9.29.0",
         "happy-dom": ">=20.8.9",
         "laravel-echo": "^2.5.0",
+        "pusher-js": "^8.6.0",
         "typescript-eslint": "^8.34.1",
         "vite": "^7.1.3",
         "vitest": "^3.2.3"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
     "devDependencies": {
         "@eslint/js": "^9.29.0",
         "@inertiajs/core": "^3.1.0",
+        "@laravel/echo-react": "^2.5.0",
+        "@laravel/echo-vue": "^2.5.0",
         "@types/node": "^22.7.5",
         "axios": "^1.20.0",
         "eslint": "^9.29.0",
         "happy-dom": ">=20.8.9",
+        "laravel-echo": "^2.5.0",
         "typescript-eslint": "^8.34.1",
         "vite": "^7.1.3",
         "vitest": "^3.2.3"

--- a/src/Converters/BroadcastEvents.php
+++ b/src/Converters/BroadcastEvents.php
@@ -65,14 +65,13 @@ class BroadcastEvents extends Converter
             ),
         );
 
-        $content = [];
+        $imports = Imports::create()->addSideEffect($echoPackage);
 
         if ($namespaceRoots->isNotEmpty()) {
-            $content[] = (string) Imports::create()->add('./types', $namespaceRoots->all());
-            $content[] = '';
+            $imports->add('./types', $namespaceRoots->all());
         }
 
-        return implode(PHP_EOL, $content).PHP_EOL.TypeScript::module(
+        return $imports.PHP_EOL.PHP_EOL.TypeScript::module(
             $echoPackage,
             TypeScript::interface('Events', $eventsInterface->implode(PHP_EOL))
         );
@@ -127,6 +126,6 @@ class BroadcastEvents extends Converter
 
     protected function toEventName(string $name)
     {
-        return '.'.str_replace('\\', '.', $name);
+        return '.'.$name;
     }
 }

--- a/src/Converters/BroadcastEvents.php
+++ b/src/Converters/BroadcastEvents.php
@@ -24,9 +24,6 @@ class BroadcastEvents extends Converter
         $results = [];
 
         $namespacedEvents = $events->filter(fn ($event) => str_contains($event->name, '\\'));
-        $namespaceRoots = $namespacedEvents
-            ->map(fn (BroadcastEvent $event) => str($event->name)->before('\\')->toString())
-            ->unique();
         $grouped = $events->groupBy(fn (BroadcastEvent $event) => $event->name);
 
         $namespacedEvents->each(
@@ -43,14 +40,14 @@ class BroadcastEvents extends Converter
 
         $results[] = new Result('broadcast-events.ts', $this->fileContent($grouped));
 
-        if ($echoPackageContent = $this->echoFileContent($grouped, $namespaceRoots)) {
+        if ($echoPackageContent = $this->echoFileContent($grouped)) {
             $results[] = new Result('echo-broadcast-events.d.ts', $echoPackageContent);
         }
 
         return $results;
     }
 
-    protected function echoFileContent(Collection $grouped, Collection $namespaceRoots): ?string
+    protected function echoFileContent(Collection $grouped): ?string
     {
         $echoPackage = Npm::findFirstInstalledPackage(['@laravel/echo-vue', '@laravel/echo-react']);
 
@@ -58,17 +55,26 @@ class BroadcastEvents extends Converter
             return null;
         }
 
-        $eventsInterface = $grouped->map(
-            fn ($events, $key) => (string) TypeScript::objectKeyValue(
+        $eventPayloads = $grouped->map(
+            fn ($events) => (string) TypeScript::objectToTypeObject($events->first()->data->value, false),
+        );
+
+        $eventsInterface = $eventPayloads->map(
+            fn ($payload, $key) => (string) TypeScript::objectKeyValue(
                 $this->toEventName($key),
-                TypeScript::objectToTypeObject($events->first()->data->value, false)
+                $payload,
             ),
         );
 
+        // Ignore JSON-quoted payload keys when discovering type references.
+        $unquotedPayloads = preg_replace('/"(?:[^"\\\\]|\\\\.)*"/', '', $eventPayloads->implode(PHP_EOL));
+
+        preg_match_all('/(?<!\.)([A-Z][a-zA-Z0-9]*)(?=\.[A-Z])/', $unquotedPayloads, $matches);
+
         $imports = Imports::create()->addSideEffect($echoPackage);
 
-        if ($namespaceRoots->isNotEmpty()) {
-            $imports->add('./types', $namespaceRoots->all());
+        if (count($matches[0]) > 0) {
+            $imports->add('./types', $matches[0]);
         }
 
         return $imports.PHP_EOL.PHP_EOL.TypeScript::module(

--- a/tests/BroadcastEvents.test.ts
+++ b/tests/BroadcastEvents.test.ts
@@ -1,7 +1,26 @@
-import { describe, expect, test } from "vitest";
+import Echo from "laravel-echo";
+import { describe, expect, test, vi } from "vitest";
 import { BroadcastEvents } from "../workbench/resources/js/wayfinder/broadcast-events";
 
 describe("BroadcastEvents", () => {
+    test("subscribes Echo to Laravel's fully qualified event name", () => {
+        const bind = vi.fn();
+        const echo = new Echo({
+            broadcaster: "pusher",
+            client: { subscribe: () => ({ bind }) },
+            namespace: "Custom.Events",
+            withoutInterceptors: true,
+        });
+        const listener = vi.fn();
+
+        echo.channel("orders.1").listen(
+            BroadcastEvents.App.Events.OrderShipped,
+            listener,
+        );
+
+        expect(bind).toHaveBeenCalledWith("App\\Events\\OrderShipped", listener);
+    });
+
     test("exports BroadcastEvents object", () => {
         expect(BroadcastEvents).toBeDefined();
         expect(typeof BroadcastEvents).toBe("object");
@@ -14,13 +33,13 @@ describe("BroadcastEvents", () => {
 
     test("has OrderShipped event in nested structure", () => {
         expect(BroadcastEvents.App.Events.OrderShipped).toBe(
-            ".App.Events.OrderShipped"
+            ".App\\Events\\OrderShipped",
         );
     });
 
     test("has UserNotification event in nested structure", () => {
         expect(BroadcastEvents.App.Events.UserNotification).toBe(
-            ".App.Events.UserNotification"
+            ".App\\Events\\UserNotification",
         );
     });
 

--- a/tests/Feature/BroadcastEventsTest.php
+++ b/tests/Feature/BroadcastEventsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Laravel\Ranger\Components\BroadcastEvent;
+use Laravel\Surveyor\Types\Type;
+use Laravel\Wayfinder\Converters\BroadcastEvents;
+use Laravel\Wayfinder\Registry\ResultConverter;
+use Laravel\Wayfinder\Registry\TypeScriptConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class BroadcastEventsTest extends TestCase
+{
+    #[DataProvider('echoPackages')]
+    public function test_custom_events_augment_existing_echo_exports_and_infer_payloads(string $echoPackage): void
+    {
+        $rootPath = dirname(__DIR__, 2);
+        $tempPath = $rootPath.'/node_modules/.cache/wayfinder-echo-'.uniqid();
+        $files = new Filesystem;
+        $container = Container::getInstance();
+
+        try {
+            $files->ensureDirectoryExists($tempPath);
+            $files->put($tempPath.'/package.json', json_encode([
+                'dependencies' => [$echoPackage => '*'],
+            ]));
+
+            new Application($tempPath);
+
+            if (! ResultConverter::getRegistry()->hasConverter(TypeScriptConverter::class)) {
+                ResultConverter::register(TypeScriptConverter::class);
+            }
+
+            $event = (new BroadcastEvent(
+                'order.shipped',
+                'App\\Events\\OrderShipped',
+                Type::array(['orderId' => Type::int()]),
+            ))->setFilePath($rootPath.'/workbench/app/Events/OrderShipped.php');
+
+            foreach ((new BroadcastEvents)->convert(collect([$event])) as $result) {
+                $files->put($tempPath.'/'.$result->name, $result->content());
+            }
+
+            $files->put($tempPath.'/consumer.ts', <<<TS
+                import { useEcho } from "{$echoPackage}";
+                import { BroadcastEvents } from "./broadcast-events";
+
+                useEcho("orders.1", BroadcastEvents.order.shipped, (event) => {
+                    event.orderId.toFixed();
+                    // @ts-expect-error Event payloads must retain their generated types.
+                    event.orderId.toUpperCase();
+                    // @ts-expect-error Unknown payload properties must be rejected.
+                    event.missing;
+                });
+                TS);
+            $files->put($tempPath.'/tsconfig.json', json_encode([
+                'extends' => $rootPath.'/tsconfig.json',
+                'compilerOptions' => ['rootDir' => '.'],
+                'include' => ['*.ts'],
+                'exclude' => [],
+            ]));
+
+            $process = new Process([$rootPath.'/node_modules/.bin/tsc', '--noEmit', '-p', $tempPath], $rootPath);
+            $process->setTimeout(60);
+            $process->run();
+
+            $this->assertTrue($process->isSuccessful(), $process->getErrorOutput().$process->getOutput());
+        } finally {
+            Container::setInstance($container);
+            $files->deleteDirectory($tempPath);
+        }
+    }
+
+    public static function echoPackages(): array
+    {
+        return [
+            'React' => ['@laravel/echo-react'],
+            'Vue' => ['@laravel/echo-vue'],
+        ];
+    }
+}

--- a/tests/Feature/BroadcastEventsTest.php
+++ b/tests/Feature/BroadcastEventsTest.php
@@ -2,12 +2,19 @@
 
 namespace Tests\Feature;
 
+use App\Models\User;
+use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Application;
+use Laravel\Ranger\Collectors\Models as ModelCollector;
 use Laravel\Ranger\Components\BroadcastEvent;
+use Laravel\Surveyor\SurveyorServiceProvider;
+use Laravel\Surveyor\Types\ClassType;
 use Laravel\Surveyor\Types\Type;
 use Laravel\Wayfinder\Converters\BroadcastEvents;
+use Laravel\Wayfinder\Converters\Models;
+use Laravel\Wayfinder\Langs\TypeScript;
 use Laravel\Wayfinder\Registry\ResultConverter;
 use Laravel\Wayfinder\Registry\TypeScriptConverter;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -16,8 +23,8 @@ use Symfony\Component\Process\Process;
 
 class BroadcastEventsTest extends TestCase
 {
-    #[DataProvider('echoPackages')]
-    public function test_custom_events_augment_existing_echo_exports_and_infer_payloads(string $echoPackage): void
+    #[DataProvider('broadcastEvents')]
+    public function test_events_augment_existing_echo_exports_and_infer_payloads(string $echoPackage, string $eventName, bool $withModel): void
     {
         $rootPath = dirname(__DIR__, 2);
         $tempPath = $rootPath.'/node_modules/.cache/wayfinder-echo-'.uniqid();
@@ -30,37 +37,69 @@ class BroadcastEventsTest extends TestCase
                 'dependencies' => [$echoPackage => '*'],
             ]));
 
-            new Application($tempPath);
+            $app = new Application($tempPath);
+            $app->instance('config', new Repository);
+            $app->register(SurveyorServiceProvider::class);
 
             if (! ResultConverter::getRegistry()->hasConverter(TypeScriptConverter::class)) {
                 ResultConverter::register(TypeScriptConverter::class);
             }
 
+            $payload = [
+                'orderId' => Type::int(),
+                'Order.Shipped' => Type::int(),
+                'Shipment "Order.Shipped"' => Type::int(),
+            ];
+
+            if ($withModel) {
+                $models = $app->make(ModelCollector::class)
+                    ->setAppPaths($rootPath.'/workbench/app/Models')
+                    ->collect();
+
+                foreach ($models as $model) {
+                    (new Models)->convert($model);
+                }
+
+                $payload['user'] = new ClassType(User::class);
+            }
+
             $event = (new BroadcastEvent(
-                'order.shipped',
+                $eventName,
                 'App\\Events\\OrderShipped',
-                Type::array(['orderId' => Type::int()]),
+                Type::array($payload),
             ))->setFilePath($rootPath.'/workbench/app/Events/OrderShipped.php');
 
             foreach ((new BroadcastEvents)->convert(collect([$event])) as $result) {
                 $files->put($tempPath.'/'.$result->name, $result->content());
             }
 
+            $files->put($tempPath.'/types.ts', TypeScript::getNamespacedFormatted()->implode(PHP_EOL));
+
+            $eventPath = str_replace('\\', '.', $eventName);
+            $modelAssertions = $withModel ? <<<'TS'
+                    event.user.id.toFixed();
+                    // @ts-expect-error Referenced model attributes must retain their types.
+                    event.user.id.toUpperCase();
+                TS : '';
+
             $files->put($tempPath.'/consumer.ts', <<<TS
                 import { useEcho } from "{$echoPackage}";
                 import { BroadcastEvents } from "./broadcast-events";
 
-                useEcho("orders.1", BroadcastEvents.order.shipped, (event) => {
+                useEcho("orders.1", BroadcastEvents.{$eventPath}, (event) => {
                     event.orderId.toFixed();
+                    event["Order.Shipped"].toFixed();
+                    event['Shipment "Order.Shipped"'].toFixed();
                     // @ts-expect-error Event payloads must retain their generated types.
                     event.orderId.toUpperCase();
                     // @ts-expect-error Unknown payload properties must be rejected.
                     event.missing;
+                    {$modelAssertions}
                 });
                 TS);
             $files->put($tempPath.'/tsconfig.json', json_encode([
                 'extends' => $rootPath.'/tsconfig.json',
-                'compilerOptions' => ['rootDir' => '.'],
+                'compilerOptions' => ['rootDir' => '.', 'skipLibCheck' => false],
                 'include' => ['*.ts'],
                 'exclude' => [],
             ]));
@@ -76,11 +115,15 @@ class BroadcastEventsTest extends TestCase
         }
     }
 
-    public static function echoPackages(): array
+    public static function broadcastEvents(): array
     {
         return [
-            'React' => ['@laravel/echo-react'],
-            'Vue' => ['@laravel/echo-vue'],
+            'React scalar alias' => ['@laravel/echo-react', 'order.shipped', false],
+            'Vue scalar alias' => ['@laravel/echo-vue', 'order.shipped', false],
+            'React model alias' => ['@laravel/echo-react', 'order.shipped', true],
+            'Vue model alias' => ['@laravel/echo-vue', 'order.shipped', true],
+            'React cross-namespace model' => ['@laravel/echo-react', 'Domain\\Events\\OrderShipped', true],
+            'Vue cross-namespace model' => ['@laravel/echo-vue', 'Domain\\Events\\OrderShipped', true],
         ];
     }
 }


### PR DESCRIPTION
Generated broadcast event names replace PHP namespace separators with dots while also using Echo's leading-dot escape. Echo therefore subscribes to `App.Events.OrderShipped` instead of Laravel's `App\Events\OrderShipped`, and the listener never receives the event.

Preserve the original event name after the escape prefix. The exported object structure and custom broadcast aliases remain unchanged.

Also import the installed Echo package before augmenting its `Events` interface, so applications containing only custom aliases retain Echo's existing exports. Derive imports from referenced payload types instead of event namespaces, covering aliases and events that reference models from another namespace. Quoted payload keys are excluded from type-reference detection.

Regression tests exercise Echo's real event formatter and compile generated declarations against the React and Vue adapters, checking payload inference and invalid property access. Added dependencies are development-only and support these integration tests.

Local validation on PHP 8.5 with Laravel 12.69.2 and 13.31.0:

- The complete `npm test` command passes on both versions: PHPUnit, Vitest in all three modes, generated-code linting, and TypeScript checks.
- PHPUnit: 39 tests and 176 assertions on each version.
- Pint and `git diff --check` pass.
